### PR TITLE
Daemonize on start

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard.init
+++ b/ext/packaging/redhat/puppet-dashboard.init
@@ -44,7 +44,7 @@ start() {
         # debugging output (or a real exit code) if it fails to start.
         # Also: We don't have reliable access to start-stop-daemon.
 
-        su -s /bin/sh -c "${DASHBOARD_RUBY} ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE}" ${DASHBOARD_USER} &
+        su -s /bin/sh -c "${DASHBOARD_RUBY} ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE} -d" ${DASHBOARD_USER} &
         local PID=$!
         echo $PID > ${PIDFILE}
 


### PR DESCRIPTION
Red Hat init script needs -d parameter to ensure puppet-dashboard daemonizes. Otherwise it will run as the current user (and output to console) and quit when that user logs out.
