### PR TITLE
Adjust redhat workers init script to also use a customizable ruby path

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard-workers.init
+++ b/ext/packaging/redhat/puppet-dashboard-workers.init
@@ -27,6 +27,9 @@ name=puppet-dashboard-workers
 # name=pe-dashboard-workers
 
 # pull in sysconfig settings
+# first the general dashboard settings, then the dedicated settings for
+# the workers
+[ -f /etc/sysconfig/puppet-dashboard ] && . /etc/sysconfig/puppet-dashboard
 [ -f /etc/sysconfig/$name ] && . /etc/sysconfig/$name
 
 # The default dashboard root if not set in sysconfig
@@ -43,7 +46,7 @@ start()
 		export PATH='${PATH}';
 		export RUBYLIB='${RUBYLIB:-}';
 		export RAILS_ENV=production;
-		${DASHBOARD_ROOT}/script/delayed_job -p dashboard -n ${CPUS:-2} -m start;'"
+		${DASHBOARD_RUBY} ${DASHBOARD_ROOT}/script/delayed_job -p dashboard -n ${CPUS:-2} -m start;'"
 	RETVAL=$?
 	[ $RETVAL -eq 0 ] && touch $lockfile
 	echo
@@ -57,7 +60,7 @@ stop()
 		export PATH='${PATH}';
 		export RUBYLIB='${RUBYLIB}';
 		export RAILS_ENV=production;
-		'${DASHBOARD_ROOT}/script/delayed_job' -p dashboard -n ${CPUS:-2} -m stop;"
+		${DASHBOARD_RUBY} ${DASHBOARD_ROOT}/script/delayed_job -p dashboard -n ${CPUS:-2} -m stop;"
 	RETVAL=$?
 	[ $RETVAL -eq 0 ] && (rm -f $lockfile; echo_success) || echo_failure
 	echo


### PR DESCRIPTION
While we are able to set an alternative RUBY path for the dashboard
server this is not possible for the workers.
We now include first the general dashboard sysconfig and afterwards
a (possible) dedicated workers sysconfig file, which could overwrite
the general dashboard settings.
This means that if you would adjust RUBY for the dashboard-server it
would also be used for the workers.
