### PR TITLE
Ticket/1.2rc/8790 reports columns

### DIFF
--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -34,19 +34,20 @@
               %td= link_to report.time, report
               - unless @node
                 %td= link_to_if report.node, h(report.host), node_path(report.node)
-              %td= report.total_resources
-              %td= report.failed_resources
-              %td= report.changed_resources
-              %td= report.unchanged_resources
-              %td= report.skipped_resources
-              %td= report.failed_restarts
+              %td= report.total_resources.to_i
+              %td= report.failed_resources.to_i
+              %td= report.changed_resources.to_i
+              %td= report.unchanged_resources.to_i
+              %td= report.pending_resources.to_i
+              %td= report.skipped_resources.to_i
+              %td= report.failed_restarts.to_i
               %td #{report.config_retrieval_time} s
               %td #{report.total_time} s
           - if @reports.total_pages > 1
             %tfoot
               %tr
-                %td{:colspan => @node ? 10 : 9}
+                %td{:colspan => @node ? 13 : 12}
                   = pagination_for(@reports)
         - else
-          %td.empty{:colspan => @node ? 10 : 9}
+          %td.empty{:colspan => @node ? 13 : 12}
             = describe_no_matches_for :@reports


### PR DESCRIPTION
The columns on the reports page didn't line up because we weren't
showing pending report counts.  Also, the counts were showing as decimal
numbers when they are really all integer results.  Unfortunately, the
metrics table those numbers come from is generalized so that you can
store any kind of number, so the results default to displaying as
decimal, and the only real way to fix that display is in the view.
