### PR TITLE
(#8796) Re-write misleading 500 error message

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -5,7 +5,7 @@
 
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>Puppet Dashboard encountered an error (500)</title>
 	<style type="text/css">
 		body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
 		div.dialog {
@@ -23,8 +23,8 @@
 <body>
   <!-- This file lives in public/500.html -->
   <div class="dialog">
-    <h1>We're sorry, but something went wrong.</h1>
-    <p>We've been notified about this issue and we'll take a look at it shortly.</p>
+    <h1>Puppet Dashboard encountered an error.</h1>
+    <p>Something went wrong, and Puppet Dashboard was unable to render the requested page. Please contact your site&#8217;s help desk or systems administrator; if that happens to be you, please check Dashboard&#8217;s logs for more information.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Previously, the 500 error message read, "We've been notified about this issue
and we'll take a look at it shortly." In fact, Dashboard was not notifying
anyone, and "we" certainly weren't coming to look at it. This commit replaces
the error message with practical (albeit basic) first steps for both technical
and non-technical users.
