### PR TITLE
(#7934) Only link old file checksum to file bucket when contents have cha

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,8 +1,13 @@
 module ReportsHelper
   def popup_md5s( string, label = nil )
     if SETTINGS.use_file_bucket_diffs
-      string.gsub(/\{md5\}[a-fA-F0-9]{32}/) do |match|
-        link_to_function label || match, "display_file_popup('#{url_for :controller => :files, :action => :show, :file => match.sub('{md5}','')}')", :class => 'popup-md5'
+      string.sub(/content changed '(\{md5\}[a-fA-F0-9]{32})'/) do |match|
+        hash = $1
+        label ||= hash
+        filebucket_url = url_for(:controller => :files, :action => :show, :file => hash.sub('{md5}',''))
+        function_link = link_to_function(label, "display_file_popup('#{filebucket_url}')", :class => 'popup-md5')
+
+        "content changed '#{function_link}'"
       end
     else
       string

--- a/spec/helpers/reports_helper_spec.rb
+++ b/spec/helpers/reports_helper_spec.rb
@@ -1,11 +1,41 @@
-require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'spec_helper'
 
 describe ReportsHelper do
+  describe 'popup_md5s' do
+    describe 'when SETTINGS.use_file_bucket_diffs is disabled' do
+      before :each do
+        SETTINGS.stubs(:use_file_bucket_diffs).returns(false)
+      end
 
-  #Delete this example and add some real ones or delete this file
-  it "should be included in the object returned by #helper" do
-    included_modules = (class << helper; self; end).send :included_modules
-    included_modules.should include(ReportsHelper)
+      it "should not link the original file's checksum to the file-bucket when contents have changed" do
+        helper.popup_md5s(
+          "content changed '{md5}acbd18db4cc2f85cedef654fccc4a4d8' to '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+        ).should == "content changed '{md5}acbd18db4cc2f85cedef654fccc4a4d8' to '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+      end
+
+      it "should not link new files checksums to the file-bucket" do
+        helper.popup_md5s(
+          "defined content as '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+        ).should == "defined content as '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+      end
+    end
+
+    describe 'when SETTINGS.use_file_bucket_diffs is enabled' do
+      before :each do
+        SETTINGS.stubs(:use_file_bucket_diffs).returns(true)
+      end
+
+      it "should link the original file's checksum to the file-bucket when contents have changed" do
+        helper.popup_md5s(
+          "content changed '{md5}acbd18db4cc2f85cedef654fccc4a4d8' to '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+        ).should == "content changed '<a class=\"popup-md5\" href=\"#\" onclick=\"display_file_popup('/files/show?file=acbd18db4cc2f85cedef654fccc4a4d8'); return false;\">{md5}acbd18db4cc2f85cedef654fccc4a4d8</a>' to '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+      end
+
+      it "should not link new files checksums to the file-bucket" do
+        helper.popup_md5s(
+          "defined content as '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+        ).should == "defined content as '{md5}37b51d194a7513e45b56f6524f2d51f2'"
+      end
+    end
   end
-
 end


### PR DESCRIPTION
(#7934) Only link old file checksum to file bucket when contents have changed

The file bucket is only populated with the old contents of a file,
when the file is changed by Puppet.  Since the new contents of the
file are not put into the file bucket, the links that were shown for
the new file contents would only work if there was a file previously
had that particular checksum.

Now, we only make the checksum a link to view the contents from the
file bucket if the checksum is for the old file contents, and do not
show the link for the new file contents, or if the file was created in
that puppet run.

This does mean that we are hiding the link in cases where there is a
chance that the file contents could actually be shown.  For example,
if we are looking at an old report where a file was created, but the
contents were changed in later Puppet runs.
