### PR TITLE
(#9182) Fix ability to add classes and groups on creation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,4 +52,18 @@ class ApplicationController < ActionController::Base
       params[param][:parameters] = {}
     end
   end
+
+  def set_group_and_class_autocomplete_data_sources(source_object)
+    @class_data = {
+      :class       => '#node_class_ids',
+      :data_source => node_classes_path(:format => :json),
+      :objects     => source_object.node_classes
+    } if SETTINGS.use_external_node_classification
+
+    @group_data = {
+      :class       => '#node_group_ids',
+      :data_source => node_groups_path(:format => :json),
+      :objects     => source_object.node_groups
+    }
+  end
 end

--- a/app/controllers/node_groups_controller.rb
+++ b/app/controllers/node_groups_controller.rb
@@ -4,13 +4,36 @@ class NodeGroupsController < InheritedResources::Base
 
   include SearchableIndex
 
+  def new
+    new! do |format|
+      format.html {
+        set_group_and_class_autocomplete_data_sources(@node_group)
+      }
+    end
+  end
+
+  def create
+    create! do |success, failure|
+      failure.html {
+        set_group_and_class_autocomplete_data_sources(@node_group)
+        render :new
+      }
+    end
+  end
+
   def edit
     edit! do |format|
       format.html {
-        if SETTINGS.use_external_node_classification
-          @class_data = {:class => '#node_class_ids', :data_source => node_classes_path(:format => :json), :objects => @node_group.node_classes}
-        end
-        @group_data = {:class => '#node_group_ids', :data_source => node_groups_path(:format => :json),  :objects => @node_group.node_groups}
+        set_group_and_class_autocomplete_data_sources(@node_group)
+      }
+    end
+  end
+
+  def update
+    update! do |success, failure|
+      failure.html {
+        set_group_and_class_autocomplete_data_sources(@node_group)
+        render :edit
       }
     end
   end

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -15,6 +15,23 @@ class NodesController < InheritedResources::Base
     define_method(action) {scoped_index :unhidden, action}
   end
 
+  def new
+    new! do |format|
+      format.html {
+        set_group_and_class_autocomplete_data_sources(@node)
+      }
+    end
+  end
+
+  def create
+    create! do |success, failure|
+      failure.html {
+        set_group_and_class_autocomplete_data_sources(@node)
+        render :new
+      }
+    end
+  end
+
   def hidden
     scoped_index :hidden
   end
@@ -50,10 +67,16 @@ class NodesController < InheritedResources::Base
   def edit
     edit! do |format|
       format.html {
-        if SETTINGS.use_external_node_classification
-          @class_data = {:class => '#node_class_ids', :data_source => node_classes_path(:format => :json), :objects => @node.node_classes}
-        end
-        @group_data = {:class => '#node_group_ids', :data_source => node_groups_path(:format => :json),  :objects => @node.node_groups}
+        set_group_and_class_autocomplete_data_sources(@node)
+      }
+    end
+  end
+
+  def update
+    update! do |success, failure|
+      failure.html {
+        set_group_and_class_autocomplete_data_sources(@node)
+        render :edit
       }
     end
   end

--- a/spec/controllers/node_groups_controller_spec.rb
+++ b/spec/controllers/node_groups_controller_spec.rb
@@ -10,6 +10,51 @@ describe NodeGroupsController do
   it_should_behave_like "with search by q and tag"
   it_should_behave_like "sorted index"
 
+  describe "#create" do
+    it "should create a node group on successful creation" do
+      post :create, 'node_group' => { 'name' => 'foo' }
+      assigns[:node_group].name.should == 'foo'
+    end
+
+    it "should render new when creation fails" do
+      post :create, 'node_group' => { }
+      response.should render_template('node_groups/new')
+      response.should be_success
+
+      assigns[:node_group].errors.full_messages.should == ["Name can't be blank"]
+      assigns[:class_data].should == {:class=>"#node_class_ids", :data_source=>"/node_classes.json", :objects=>[]}
+      assigns[:group_data].should == {:class=>"#node_group_ids", :data_source=>"/node_groups.json", :objects=>[]}
+    end
+  end
+
+  describe "#new" do
+    it "should successfully render the new page" do
+      get :new
+
+      response.should render_template('node_groups/new')
+      response.should be_success
+      assigns[:class_data].should == {:class=>"#node_class_ids", :data_source=>"/node_classes.json", :objects=>[]}
+      assigns[:group_data].should == {:class=>"#node_group_ids", :data_source=>"/node_groups.json", :objects=>[]}
+    end
+  end
+
+  describe '#edit' do
+    before :each do
+      @node_group = NodeGroup.generate!
+    end
+
+    it 'should render the edit template' do
+      get :edit, :id => @node_group
+      assigns[:node_group].should == @node_group
+
+      response.should render_template('edit')
+      response.should be_success
+
+      assigns[:class_data].should == {:class=>"#node_class_ids", :data_source=>"/node_classes.json", :objects=>[]}
+      assigns[:group_data].should == {:class=>"#node_group_ids", :data_source=>"/node_groups.json", :objects=>[]}
+    end
+  end
+
   describe "#update" do
     def do_put
       put :update, @params

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -138,8 +138,34 @@ describe NodesController do
     end
   end
 
+  describe "#new" do
+    it "should successfully render the new page" do
+      get :new
+
+      response.should be_success
+      assigns[:class_data].should == {:class=>"#node_class_ids", :data_source=>"/node_classes.json", :objects=>[]}
+      assigns[:group_data].should == {:class=>"#node_group_ids", :data_source=>"/node_groups.json", :objects=>[]}
+    end
+  end
+
+  describe "#create" do
+    it "should create a node on successful creation" do
+      post :create, 'node' => { 'name' => 'foo' }
+      assigns[:node].name.should == 'foo'
+    end
+
+    it "should render new when creation fails" do
+      post :create, 'node' => { }
+      response.should render_template('nodes/new')
+      response.should be_success
+
+      assigns[:node].errors.full_messages.should == ["Name can't be blank"]
+      assigns[:class_data].should == {:class=>"#node_class_ids", :data_source=>"/node_classes.json", :objects=>[]}
+      assigns[:group_data].should == {:class=>"#node_group_ids", :data_source=>"/node_groups.json", :objects=>[]}
+    end
+  end
+
   describe "#show" do
-    integrate_views
 
     before :each do
       @node = Node.generate!
@@ -230,22 +256,26 @@ describe NodesController do
 
     before :each do
       @node = Node.generate!
+    end
 
-      it 'should make the requested node available to the view' do
-        do_get
-        assigns[:node].should == @node
-      end
+    it 'should render the edit template' do
+      do_get
+      assigns[:node].should == @node
 
-      it 'should render the edit template' do
-        do_get
-        response.should render_template('edit')
-      end
+      response.should render_template('edit')
+      response.should be_success
 
-      it 'should work when given a node name' do
-        get :edit, :id => @node.name
+      assigns[:class_data].should == {:class=>"#node_class_ids", :data_source=>"/node_classes.json", :objects=>[]}
+      assigns[:group_data].should == {:class=>"#node_group_ids", :data_source=>"/node_groups.json", :objects=>[]}
+    end
 
-        assigns[:node].should == @node
-      end
+    it 'should work when given a node name' do
+      get :edit, :id => @node.name
+
+      response.should render_template('edit')
+      response.should be_success
+
+      assigns[:node].should == @node
     end
   end
 


### PR DESCRIPTION
When trying to add a class or group when creating a group or node the
autocomplete didn't work, and if you entered anything you got the
following error:

```
Couldn't find NodeClass with ID=foo
RAILS_ROOT: /Users/matthewrobinson/work/puppet-dashboard

Application Trace | Framework Trace | Full Trace
/Users/matthewrobinson/work/puppet-dashboard/vendor/rails/activerecord/lib/active_record/base.rb:1620:in `find_one'
/Users/matthewrobinson/work/puppet-dashboard/vendor/rails/activerecord/lib/active_record/base.rb:1603:in `find_from_ids'
/Users/matthewrobinson/work/puppet-dashboard/vendor/rails/activerecord/lib/active_record/base.rb:620:in `find'
/Users/matthewrobinson/work/puppet-dashboard/app/models/node_class.rb:35:in `find_from_form_ids'
/Users/matthewrobinson/work/puppet-dashboard/app/models/node_class.rb:35:in `map'
/Users/matthewrobinson/work/puppet-dashboard/app/models/node_class.rb:35:in `find_from_form_ids'
/Users/matthewrobinson/work/puppet-dashboard/app/models/node_group.rb:50:in `assign_node_classes'
```

The problem was that there was a tokenize_input_class method that uses javascript
to map node and class names to ids, and it's wasn't getting the data it needed on
most pages.

Reviewed-by: Nick Lewis nick@puppetlabs.com
