### PR TITLE
(#9195) Use a shorter date format for the report status graph

### DIFF
--- a/app/views/statuses/_run_failure.html.haml
+++ b/app/views/statuses/_run_failure.html.haml
@@ -13,7 +13,7 @@
     %thead
       %tr.labels
         - statuses.each do |status|
-          %th= status.start.to_s(:date)
+          %th= status.start.strftime('%Y-%m-%d')
     %tbody
       %tr.unchanged
         - statuses.each do |status|


### PR DESCRIPTION
Ticket #8505 changed the default date format to be long and verbose
(friendly), but the graph doesn't play well with rendering long dates
and cuts them off.

This change hard codes the date format for the graph.
