### PR TITLE
(#9101) Fix Dashboard workers init script on RH

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard-workers.init
+++ b/ext/packaging/redhat/puppet-dashboard-workers.init
@@ -2,23 +2,11 @@
 #
 # puppet-dashboard-workers		Start up the puppet-dashboard-workers
 #
-# chkconfig: 95 5
+# chkconfig: - 95 5
 # description: Delayed_job (or DJ) encapsulates the common pattern of \
 #              asynchronously executing longer tasks in the background.
 #
 # processname: puppet-dashboard-workers
-
-### BEGIN INIT INFO
-# Provides: puppet-dashboard-workers
-# Required-Start: $local_fs $network $syslog
-# Required-Stop: $local_fs $syslog
-# Should-Start: $syslog
-# Should-Stop: $network $syslog
-# Default-Start: 2 3 4 5
-# Default-Stop: 0 1 6
-# Short-Description: puppet-dashboard-workers
-# Description: puppet-dashboard-workers
-### END INIT INFO
 
 # source function library
 . /etc/rc.d/init.d/functions


### PR DESCRIPTION
The Red Hat Dashboard workers init script last set of fixes had a typo
that caused it not to be recognized by chkconfig.  This patch fixes that
so the script is usable by chkconfig. It also removes duplicate and
possibly conflicting blocks of comments that chkconfig can read.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
