### PR TITLE
(#9282) Change user in database.yml.example to "dashboard"

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,45 +1,48 @@
-# database.yml
-# ============
-#
-# The `config/database.yml` file contains your custom settings for connecting
-# the Dashboard to a database. You must create the databases you plan to use
-# and add their connection details here to use the Dashboard.
-#
-# Format
-# ------
-#
-# This file is split into sections describing different environments, each
-# optimized for a different use. If you're only using the Dashboard, you
-# only need to configure the "production" environment.
-#
-# Lines starting with an octothorpe ("#") are comments. Uncommented,
-# unindented lines start a new environment (e.g., "production"). Indented
-# lines below an unindented line are settings related to that environment.
-#
-# Example
-# -------
-#
-#     # Section describing the "production" environment, don't change this line:
-#     production:
-#         # Connect to a database named "dashboard":
-#         database: dashboard
-#         # Connect to this database as the "root" user:
-#         username: root
-#         # Connect to this database using "mypassword" as the password:
-#         password: mypassword
-#         # Use "utf8" as the database character encoding, don't change this line:
-#         encoding: utf8
-#         # Use a MySQL database, don't change this line:
-#         adapter: mysql
-#
-# Environments
-# ------------
-#
-# The "production" environment is optimized for fast performance, like when
-# you deploy the Dashboard for use in your organization. It is used when:
-# * Starting a console with: script/console production
-# * Starting a server with: scipt/server -e production
-# * Running a rake task with: rake RAILS_ENV=production ...
+# config/database.yml
+# 
+# IMPORTANT NOTE: Before starting Dashboard, you will need to ensure that the
+# MySQL user and databases you've specified in this file exist, and that the
+# user has all permissions on the relevant databases. This will have to be done
+# with an external database administration tool. If using the command-line
+# `mysql` client, the commands to do this will resemble the following:
+# 
+# CREATE DATABASE dashboard_production CHARACTER SET utf8;
+# CREATE USER 'dashboard'@'localhost' IDENTIFIED BY 'my_password';
+# GRANT ALL PRIVILEGES ON dashboard_production.* TO 'dashboard'@'localhost';
+# 
+# -----
+# 
+# This file should be a YAML hash with one key for each of the standard Rails
+# environments: production, development, and test.
+# 
+# - The "production" environment gives the best performance, and should be used
+#   most of the time by most users. **Note that Rails does not consider
+#   production its default environment, and you must specify it manually with
+#   the RAILS_ENV environment variable when running any rake tasks.**
+# - The "development" environment gives worse performance, but yields better
+#   logging and error reporting when something goes wrong.
+# - The "test" environment is only used for running Dashboard's automated tests.
+#   It should never be used by most users. If you are using the test
+#   environment, **DO NOT set its database to the same database used by the
+#   development or production environments,** as it will be erased and
+#   re-written every time the automated tests are run.
+# 
+# The environment is set when Dashboard is started, a console is started, or a
+# rake task is run. Most production-quality Rails servers (such as Passenger)
+# will default to the production environment, but the included WEBrick server
+# script will default to development unless run with the `-e production` option.
+# 
+# Each environment should be a hash with keys for:
+# 
+# - database
+# - username
+# - password
+# - encoding
+# - adapter
+# 
+# At the moment, "adapter" can only be "mysql", and "encoding" should always
+# be "utf8".
+# 
 production:
   database: dashboard_production
   username: dashboard
@@ -47,11 +50,6 @@ production:
   encoding: utf8
   adapter: mysql
 
-# The "development" environment is optimized for those developing the
-# Dashboard software and reloads code as it's modified. It is used when:
-# * Starting a console with: script/console
-# * Starting a server with: script/server
-# * Running a rake task with: rake ...
 development:
   database: dashboard_development
   username: dashboard
@@ -59,10 +57,6 @@ development:
   encoding: utf8
   adapter: mysql
 
-# The "test" environment is used for running tests. WARNING: The database
-# defined for this will be erased and re-generated from your development
-# database when you run "rake". Do NOT set this db to the same as
-# "development" or "production".
 test:
   database: dashboard_test
   username: dashboard


### PR DESCRIPTION
Previously, our database.yml.example file suggested handing the keys to the
root MySQL user to Dashboard, which is a poor security practice. This commit
changes the default user suggestion to "dashboard", which is the default MySQL
user used in Puppet Enterprise.
