### PR TITLE
(#9423) Fix broken RH init script in dashboard

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard-workers.init
+++ b/ext/packaging/redhat/puppet-dashboard-workers.init
@@ -2,7 +2,7 @@
 #
 # puppet-dashboard-workers		Start up the puppet-dashboard-workers
 #
-# chkconfig: 95 5
+# chkconfig: - 95 5
 # description: Delayed_job (or DJ) encapsulates the common pattern of \
 #              asynchronously executing longer tasks in the background.
 #
@@ -14,8 +14,8 @@
 # Required-Stop: $local_fs $syslog
 # Should-Start: $syslog
 # Should-Stop: $network $syslog
-# Default-Start: 2 3 4 5
-# Default-Stop: 0 1 6
+# Default-Start: 3 4 5
+# Default-Stop: 0 1 2 6
 # Short-Description: puppet-dashboard-workers
 # Description: puppet-dashboard-workers
 ### END INIT INFO


### PR DESCRIPTION
A typo in the chkconfig values for the puppet-dashboard-workers init script was
making it unusable. Adding the missing value will address the issue. This patch
also modifies the default start runlevel to exclude 2, as level 2 does not
start networking or network services. Runlevel 2 has been added to the default
stop level.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
