### PR TITLE
(#7405) Daemonized redhat init script for dashboard

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard.init
+++ b/ext/packaging/redhat/puppet-dashboard.init
@@ -39,13 +39,12 @@ start() {
             return 0
         fi
 
-        # This is a dirty, dirty hack, but it's rather difficult to get
-        # script/server to daemonize in any way, and still give us useful
-        # debugging output (or a real exit code) if it fails to start.
-        # Also: We don't have reliable access to start-stop-daemon.
+        # This is a no longer a dirty, dirty hack, we now daemonize the server.
+        # Also: We have access to daemon.
+        daemon --user ${DASHBOARD_USER} --pidfile ${PIDFILE} "${DASHBOARD_RUBY} ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE} -d"
 
-        su -s /bin/sh -c "${DASHBOARD_RUBY} ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE}" ${DASHBOARD_USER} &
-        local PID=$!
+        # Grab the pid. pidof doesn't work well here, so we use pgrep
+        local PID=`pgrep -f "${DASHBOARD_RUBY} ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE} -d"`
         echo $PID > ${PIDFILE}
 
         sleep 5


### PR DESCRIPTION
The previous redhat init script would not daemonize, but would merely
background the dashboard server start, so running start over ssh would hang.
This patch replaces the 'su -c' with daemon and passes -d to the server start
command, so it daemonizes. Start can now be run over ssh without the hang.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
