### PR TITLE
(#9756) Autoload plugin initializers.

### DIFF
--- a/config/initializers/ZZZ_load_plugin_initializers.rb
+++ b/config/initializers/ZZZ_load_plugin_initializers.rb
@@ -1,0 +1,11 @@
+Dir.foreach(Rails.root.join('config', 'installed_plugins')) do |plugin|
+  next if plugin =~ /^\.+$/
+  plugin_dir = Rails.root.join('vendor', 'plugins', plugin)
+  initializers = plugin_dir.join('config', 'initializers')
+
+  if File.directory?(initializers)
+    Dir[initializers.join('**', '*.rb')].sort.each do |initializer|
+      load(initializer)
+    end
+  end
+end


### PR DESCRIPTION
Rails has a robust built-in mechanism for handling segregated
application-specific configuration code.  This initializer takes
the next step and uses the same approach to load initializers from
installed plugins.
