### PR TITLE
(#9756/Maint) Better guards around installed_plugins.

### DIFF
--- a/config/initializers/ZZZ_load_plugin_initializers.rb
+++ b/config/initializers/ZZZ_load_plugin_initializers.rb
@@ -1,11 +1,7 @@
-Dir.foreach(Rails.root.join('config', 'installed_plugins')) do |plugin|
-  next if plugin =~ /^\.+$/
-  plugin_dir = Rails.root.join('vendor', 'plugins', plugin)
-  initializers = plugin_dir.join('config', 'initializers')
+Dir[Rails.root.join('config', 'installed_plugins', '*')].sort.each do |plugin|
+  dir = Rails.root.join('vendor', 'plugins', plugin)
 
-  if File.directory?(initializers)
-    Dir[initializers.join('**', '*.rb')].sort.each do |initializer|
-      load(initializer)
-    end
+  Dir[dir.join('config', 'initializers', '**', '*.rb')].sort.each do |file|
+    load(file)
   end
 end

--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -51,10 +51,7 @@ class Registry
   private
 
   def installed_plugins
-    Dir.open(File.join(File.dirname(__FILE__), '../config/installed_plugins')) { |aDir|
-      @installed_plugins ||= aDir.to_a.reject { |f| f =~ /^\./ }
-    }
-    @installed_plugins
+    Dir[Rails.root.join('config', 'installed_plugins', '*')]
   end
 
   def disallow_uninstalled_plugins


### PR DESCRIPTION
The initializer added by #9756 didn't play nicely with a
Dashboard that had no plugins installed, and the Registry
didn't place nicely when you dropped a plugin into place
but didn't have an `installed_plugins` directory.

As it turns out, `Dir#glob` does exactly the right thing
in the event that any element in the path doesn't exist,
allowing us to simplify the code while simultaneously
making it more robust.
