### PR TITLE
(#9756/Maint) Fix plugin loading.

### DIFF
--- a/config/initializers/ZZZ_load_plugin_initializers.rb
+++ b/config/initializers/ZZZ_load_plugin_initializers.rb
@@ -1,4 +1,5 @@
 Dir[Rails.root.join('config', 'installed_plugins', '*')].sort.each do |plugin|
+  plugin = File.basename(plugin)
   dir = Rails.root.join('vendor', 'plugins', plugin)
 
   Dir[dir.join('config', 'initializers', '**', '*.rb')].sort.each do |file|

--- a/lib/registry.rb
+++ b/lib/registry.rb
@@ -51,7 +51,7 @@ class Registry
   private
 
   def installed_plugins
-    Dir[Rails.root.join('config', 'installed_plugins', '*')]
+    Dir[Rails.root.join('config', 'installed_plugins', '*')].map { |path| File.basename(path) }
   end
 
   def disallow_uninstalled_plugins


### PR DESCRIPTION
`Dir.glob` returns a list of paths, not filenames (most of the
time).  This actively prevented plugins from being considered
"installed", and (theoretically) from loading their initializers.
