### PR TITLE
(#9773) Report content hidden

### DIFF
--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -277,8 +277,7 @@ body {
     border-radius: 0 0 0.35em 0.35em;
     background: #FFF;
     padding: 1em;
-    margin-bottom: 1em;
-    overflow: hidden; }
+    margin-bottom: 1em; }
     body .item:last-child {
       padding-bottom: 0;
       margin-bottom: 0; }
@@ -287,8 +286,7 @@ body {
     margin-right: 5%;
     float: left; }
   body .section {
-    margin-bottom: 1.5em;
-    overflow: auto; }
+    margin-bottom: 1.5em; }
     body .section.error {
       -webkit-border-radius: 0.35em 0.35em 0.35em 0.35em;
       -moz-border-radius: 0.35em 0.35em 0.35em 0.35em;

--- a/public/stylesheets/sass/application.scss
+++ b/public/stylesheets/sass/application.scss
@@ -500,7 +500,6 @@ body {
     background: #FFF;
     padding: 1em;
     margin-bottom: 1em;
-    overflow: hidden;
 
     &:last-child {
         padding-bottom: 0;
@@ -516,7 +515,6 @@ body {
 
   .section {
     margin-bottom: 1.5em;
-    overflow: auto;
 
     &.error {
       @include icony_section('failed',


### PR DESCRIPTION
If any cell in a report table had wide content, the part of the table that would
have extended beyond the viewable window was hidden.  A scroll bar was provided
at the bottom of the content, but it was hard to find.

This change allows the table expand to the size it needs to be to display all
its content.  It allows for a horizontal scroll bar on the browser window, which
is much more visible.
