### PR TITLE
(#9940) dashboard-workers can be managed as service

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard-workers.init
+++ b/ext/packaging/redhat/puppet-dashboard-workers.init
@@ -44,7 +44,7 @@ start()
 stop()
 {
 	echo -n $"Stopping $prog: "
-	sudo -H -u puppet-dashboard bash -e -c "
+	bash -e -c "
 		export PATH='${PATH}';
 		export RUBYLIB='${RUBYLIB}';
 		export RAILS_ENV=production;


### PR DESCRIPTION
The stop command in the puppet-dashboard-workers init script would fail when
run using a puppet service resource. This had something to do with the way sudo
works on EL. Removing the sudo from the stop function allows the service to be
managed by puppet reliably. And because it is stopping the process, and not
creating the process, it doesn't matter whether it runs as root or
puppet-dashboard.

Signed-off-by: Matthaus Litteken matthaus@puppetlabs.com
