### PR TITLE
(#10035) Add attribute topbar so nav dropdown's work

### DIFF
--- a/app/views/shared/_global_nav.html.haml
+++ b/app/views/shared/_global_nav.html.haml
@@ -1,4 +1,4 @@
-.topbar
+.topbar{"data-dropdown" => "dropdown"}
   .topbar-inner
     .container
       %ul#global-navigation.navigation


### PR DESCRIPTION
Twitter's bootstrap library depends on the topbar having a data-dropdown
attribute set in order to have dropdowns on the navigation bar.
