### PR TITLE
(#10076) rc's should have a version-release less than the final.

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard.spec.erb
+++ b/ext/packaging/redhat/puppet-dashboard.spec.erb
@@ -2,7 +2,7 @@
 %global initrddir /etc/rc.d/init.d
 # VERSION is subbed out during rake srpm process
 %global realversion <%= version %>
-%define rpmversion %(echo    %{realversion} | sed -e 's/-/_/g')
+%global rpmversion <%= rpmversion %>
 
 Name:           puppet-dashboard
 Version:        %{rpmversion}


### PR DESCRIPTION
Since rpm thinks 1.2.2rcX > 1.2.2, building rpm packages for rc's
requires manual intervention to change the version and release so that
the rc's have a smaller version-release number. This fix makes the
necessary changes automatically via the rake task.
