### PR TITLE
(#10017) rc' should have a version-release less than the final.

### DIFF
--- a/ext/packaging/debian/cl.erb
+++ b/ext/packaging/debian/cl.erb
@@ -1,6 +1,6 @@
-puppet-dashboard (<%= version %>-1) intrepid jaunty karmic lucid meerkat narwhal natty lenny squeeze; urgency=low
+puppet-dashboard (<%= debversion %>) intrepid jaunty karmic lucid meerkat narwhal natty lenny squeeze; urgency=low
 
-  * build at version <%= version %>
+  * build at version <%= debversion %>
 
  -- Michael Stahnke  <stahnma@puppetlabs.com>  <%= dt  %>
 


### PR DESCRIPTION
Since debian packages think 1.2.2.rcX > 1.2.2, building deb packages
for rc's requires manual intervention to change the version so that
rc's have a smaller version number (1.2.2-0.1rcX for rc's and 1.2.2-1
for the final). This fix makes the necessary changes automatically via
the rake task.
