### PR TITLE
(#10270) dashboard-workers init script should check the right pid files

### DIFF
--- a/ext/packaging/debian/puppet-dashboard-workers.init
+++ b/ext/packaging/debian/puppet-dashboard-workers.init
@@ -40,7 +40,7 @@ check_dashboard_enabled_option() {
 
 check_puppet_dashboard_worker_status() {
     RETVAL=1
-    for pidfile in $(ls -1 "${DASHBOARD_HOME}"/tmp/pids/*.pid 2>/dev/null)
+    for pidfile in $(ls -1 "${DASHBOARD_HOME}"/tmp/pids/delayed_job.*.pid 2>/dev/null)
     do
       status_of_proc -p $pidfile ${DASHBOARD_RUBY} "Puppet Dashboard Worker (pid $(cat $pidfile))"  ||  return $?
       RETVAL=$?
@@ -53,7 +53,7 @@ check_puppet_dashboard_worker_status() {
 
 stop_puppet_dashboard_workers() {
     RETVAL=0
-    for pidfile in $(ls -1 "${DASHBOARD_HOME}"/tmp/pids/*.pid 2>/dev/null)
+    for pidfile in $(ls -1 "${DASHBOARD_HOME}"/tmp/pids/delayed_job.*.pid 2>/dev/null)
     do
       start-stop-daemon --stop --quiet --oknodo --pidfile $pidfile --retry 10
       ((RETVAL=RETVAL+$?))

--- a/ext/packaging/redhat/puppet-dashboard-workers.init
+++ b/ext/packaging/redhat/puppet-dashboard-workers.init
@@ -61,7 +61,7 @@ restart() {
 
 rh_status() {
 	RETVAL=1
-	for pidfile in $(ls -1 "${DASHBOARD_ROOT}"/tmp/pids/*.pid 2>/dev/null)
+	for pidfile in $(ls -1 "${DASHBOARD_ROOT}"/tmp/pids/delayed_job.*.pid 2>/dev/null)
 	do
 		status -p $pidfile puppet-dashboard-workers || return $?
 		RETVAL=$?


### PR DESCRIPTION
The puppet-dashboard-workers init script was using all the pidfiles in
the pid directory, it should only only consider the delayed_job
pidfiles. This fixes that.
