### PR TITLE
(#10024)  Fix typo in fix for 10024

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard-workers.init
+++ b/ext/packaging/redhat/puppet-dashboard-workers.init
@@ -29,7 +29,7 @@ lockfile=/var/lock/subsys/$prog
 start()
 {
 	echo -n $"Starting $prog: "
-	daemon --user $DAHSBOARD_USER "bash -e -c '
+	daemon --user ${DASHBOARD_USER} "bash -e -c '
 		export PATH='${PATH}';
 		export RUBYLIB='${RUBYLIB:-}';
 		export RAILS_ENV=production;


### PR DESCRIPTION
Had DASHBOARD spelled incorrectly for the DASHBOARD_USER variable in the
puppet-dashboard-workers.init file. This commit fixes the spelling.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
