### PR TITLE
(#7554) Link latest report to actual report on front page

### DIFF
--- a/app/views/nodes/_nodes.html.haml
+++ b/app/views/nodes/_nodes.html.haml
@@ -61,7 +61,7 @@
               - else
                 = sources.map{|s| link_to(s.name,s)}.join(", ")
           %td.latest_report
-            = node.last_apply_report ? node.last_apply_report.time : "Has not reported"
+            = node.last_apply_report ? link_to(h(node.last_apply_report.time), node.last_apply_report) : "Has not reported"
           - column_filter[ selected_status ].each do |status|
             %td
               = node.last_apply_report.metric_value("resources", status).to_i if node.last_apply_report


### PR DESCRIPTION
The latest report time in the node listing on the front page was
not linking to the latest report. Added an active link to the
timestamp in order to navigate to the individual report.
