### PR TITLE
(#10902) Float and block individual node sections

### DIFF
--- a/app/views/nodes/_activity.html.haml
+++ b/app/views/nodes/_activity.html.haml
@@ -1,4 +1,4 @@
-.section
+.section.half
   %h3 Dashboard activity
   - unless node.timeline_events.empty?
     %ol.timeline= render node.timeline_events.recent(10)

--- a/app/views/shared/_classes.html.haml
+++ b/app/views/shared/_classes.html.haml
@@ -18,3 +18,4 @@
                 = sources.map{|source| link_to(source.name,source)}.join(", ")
   - else
     = describe_no_matches_as 'No classes'
+%br.clear


### PR DESCRIPTION
Individual node view's sections were not floating
and clearing correctly, causing content to wrap.
Add clearfix after classes section and class type
half to active section.
