### PR TITLE
(#6717) Fix failing dependency destroy tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,11 @@ config.action_mailer.delivery_method = :test
 # Use SQL instead of Active Record's schema dumper when creating the test database.
 # This is necessary if your schema can't be completely dumped by the schema dumper,
 # like if you have constraints or database-specific column types
+# Unfortunately, this doesn't work
+# A fix was merged recently
+# https://github.com/rails/rails/issues/715
+# But not sure when they'll backport it to Rails 2.3
+# https://github.com/rails/rails/issues/743
 # config.active_record.schema_format = :sql
 
 config.gem 'mocha'

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -47,7 +47,9 @@ end
 
 Rake.application.instance_variable_get('@tasks').delete('default')
 
-spec_prereq = File.exist?(File.join(RAILS_ROOT, 'config', 'database.yml')) ? "db:test:prepare" : :noop
+# db:test:prepare loads the schema from schema.rb, which doesn't have foreign key constraints
+# db:test:clone_structure copies the schema to test from development, which will have the constraints
+spec_prereq = File.exist?(File.join(RAILS_ROOT, 'config', 'database.yml')) ? "db:test:clone_structure" : :noop
 task :noop do
 end
 

--- a/spec/models/resource_status_spec.rb
+++ b/spec/models/resource_status_spec.rb
@@ -3,7 +3,11 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe ResourceStatus do
   describe "#name" do
     it "should combine type and title" do
-      resource_status = ResourceStatus.create!(:resource_type => "File", :title => "/tmp/foo", :report_id => 142857)
+      resource_status = ResourceStatus.create!(
+        :resource_type => "File",
+        :title         => "/tmp/foo",
+        :report        => Report.generate!
+      )
       resource_status.name.should == "File[/tmp/foo]"
     end
   end


### PR DESCRIPTION
Now that there are foreign key constraints in the database that do
cascading deletes, the test database needs to have those constraints
too.  Currently, db:test:prepare is called before every spec run, which
copies schema.rb into the test database without the constraints.
Switching to db:test:clone_structure gets the schema from the dev
database which will have the right constraints.

Another possible option was to change the schema to be sql instead of
ruby, but the option to do so is currently broken.

Another possibility in the future may be to use the foreigner plugin so
that constraints can be specifiec in migrations more easily.
https://github.com/matthuhiggins/foreigner
