### PR TITLE
(#11058) deb package should have `puppetlabs` in vendor string

### DIFF
--- a/lib/tasks/package.rake
+++ b/lib/tasks/package.rake
@@ -6,7 +6,7 @@ end
 
 def get_debversion
   version = get_version
-  version.include?("rc") ? version.sub(/rc[0-9]+/, '-0.1\0') : version + '-1'
+  version.include?("rc") ? version.sub(/rc[0-9]+/, '-0.1\0') : version + '-1puppetlabs1'
 end
 
 def get_rpmversion


### PR DESCRIPTION
The deb package should make it more obvious that dashboard comes from
puppetlabs, so we add puppetlabs to the version string in the
appropriate place.
