### PR TITLE
(#11063) Building deb package should keep the source tarball

### DIFF
--- a/lib/tasks/package.rake
+++ b/lib/tasks/package.rake
@@ -109,6 +109,7 @@ namespace :package do
           cp latest_file(File.join(temp, '*.deb')), dest_dir
           cp latest_file(File.join(temp, '*.dsc')), dest_dir
           cp latest_file(File.join(temp, '*.changes')), dest_dir
+          cp latest_file(File.join(temp, '*.tar.gz')), dest_dir
           puts
           puts "** Created package: "+ latest_file(File.expand_path(File.join(RAILS_ROOT, 'pkg', 'deb', '*.deb')))
         rescue


### PR DESCRIPTION
When building the deb package, the source tarball does not get saved in
the pkg directory. Since this could be something useful to keep around,
we should save the file. We do this by copying the latest tarball out of
the temporary directory. The tar rake task also generates a tarball, but
we are guaranteed that the debian source tarball will have a later mtime
than that one.
