### PR TITLE
(#7869) Fix missing diff in dashboard Event tab

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,7 +1,8 @@
 module ReportsHelper
   def popup_md5s( string, options = {} )
     if SETTINGS.use_file_bucket_diffs
-      string.gsub(/\{md5\}[a-fA-F0-9]{32}/) do |match|
+      hashes = string.scan(/\{md5\}[a-fA-F0-9]{32}/)
+      string.gsub(/changed/, link_to_function( "\\&", "display_file_popup('#{url_for :controller => :files, :action => :diff, :file1 => hashes[0].sub('{md5}',''), :file2 => hashes[1].sub('{md5}','')}')", :class => 'popup-md5')).gsub(/\{md5\}[a-fA-F0-9]{32}/) do |match|
         if options[:exclude_md5s] and options[:exclude_md5s].include? match
           match
         else

--- a/spec/helpers/reports_helper_spec.rb
+++ b/spec/helpers/reports_helper_spec.rb
@@ -9,7 +9,13 @@ describe ReportsHelper do
 
     it "should make anything that looks like an md5 into a filebucket link" do
       helper.popup_md5s(@text).gsub(/\s/, '').should == <<-HEREDOC.gsub(/\s/, '')
-        content changed '<a
+        content <a
+          class=\"popup-md5\"
+          href=\"#\"
+          onclick=\"display_file_popup( '/files/diff?file1=b84b7c77fb71f0d945f186513a09e185&amp;file2=d28d2d3560fa76f0dbb1a452f8c38169'); 
+          return false;\">
+          changed
+        </a> '<a
           class=\"popup-md5\"
           href=\"#\"
           onclick=\"display_file_popup( '/files/show?file=b84b7c77fb71f0d945f186513a09e185'); return false;\">
@@ -25,7 +31,13 @@ describe ReportsHelper do
 
     it "should make the link text be a label if it's passed in" do
       helper.popup_md5s(@text, :label => 'foo').gsub(/\s/, '').should == <<-HEREDOC.gsub(/\s/, '')
-        content changed '<a
+        content <a
+          class=\"popup-md5\"
+          href=\"#\"
+          onclick=\"display_file_popup( '/files/diff?file1=b84b7c77fb71f0d945f186513a09e185&amp;file2=d28d2d3560fa76f0dbb1a452f8c38169'); 
+          return false;\">
+          changed
+        </a> '<a
           class=\"popup-md5\"
           href=\"#\"
           onclick=\"display_file_popup( '/files/show?file=b84b7c77fb71f0d945f186513a09e185'); return false;\">
@@ -41,7 +53,13 @@ describe ReportsHelper do
 
     it "should not link md5s if they're in the excluded list" do
       helper.popup_md5s(@text, :exclude_md5s => ['{md5}d28d2d3560fa76f0dbb1a452f8c38169']).gsub(/\s/, '').should == <<-HEREDOC.gsub(/\s/, '')
-        content changed '<a
+        content <a
+          class=\"popup-md5\"
+          href=\"#\"
+          onclick=\"display_file_popup( '/files/diff?file1=b84b7c77fb71f0d945f186513a09e185&amp;file2=d28d2d3560fa76f0dbb1a452f8c38169'); 
+          return false;\">
+          changed
+        </a> '<a
           class=\"popup-md5\"
           href=\"#\"
           onclick=\"display_file_popup( '/files/show?file=b84b7c77fb71f0d945f186513a09e185'); return false;\">


### PR DESCRIPTION
Modify event message to replace the word "changed"
to link to a diff against the previously stored
version.  Needs some additional logic to prevent
calling against a diff that wasn't previously
stored, but this is no different from current
behavior and should be refactored separately.

Modify spec file to match this behavior.
