### PR TITLE
Bug #5441 - puppet-dashboard init script is missing 'status' and 'force-reload' arguments

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard.init
+++ b/ext/packaging/redhat/puppet-dashboard.init
@@ -77,7 +77,8 @@ stop() {
 }
 
 restart () {
-        stop && start
+        stop
+        start
 }
 
 status () {


### PR DESCRIPTION
I've added a force-reload. Status was already there. While in here, I also cleaned up a bit. I fixed a return value for LSB compliance. I did a bit of refactoring to DRY things up for the force-reload. 
