### PR TITLE
(#12476) Add context to install.rake exceptions

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -46,8 +46,12 @@ namespace :cert do
     cert_req.public_key = key.public_key
     cert_req.sign(key, OpenSSL::Digest::MD5.new)
 
-    PuppetHttps.put("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_request/#{CGI::escape(SETTINGS.cn_name)}",
-                    'text/plain', cert_req.to_s, false)
+    begin
+      PuppetHttps.put("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_request/#{CGI::escape(SETTINGS.cn_name)}",
+                      'text/plain', cert_req.to_s, false)
+    rescue SocketError => e
+      raise SocketError, "Unable to contact CA server #{SETTINGS.ca_server}: #{e.message}"
+    end
   end
 
   desc "Retrieve a certificate from the Puppet Master"
@@ -55,25 +59,29 @@ namespace :cert do
     require 'openssl'
     require 'puppet_https'
     require 'cgi'
-    cert_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate/#{CGI::escape(SETTINGS.cn_name)}", 's', false)
-    cert = OpenSSL::X509::Certificate.new(cert_s)
-    key = OpenSSL::PKey::RSA.new(File.read(SETTINGS.public_key_path))
-    raise "Certificate doesn't match key" unless cert.public_key.to_s == key.to_s
-    FileUtils.mkdir_p(File.dirname(SETTINGS.certificate_path))
-    File.open(SETTINGS.certificate_path, 'w') do |file|
-      file.print cert_s
-    end
+    begin
+      cert_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate/#{CGI::escape(SETTINGS.cn_name)}", 's', false)
+      cert = OpenSSL::X509::Certificate.new(cert_s)
+      key = OpenSSL::PKey::RSA.new(File.read(SETTINGS.public_key_path))
+      raise "Certificate doesn't match key" unless cert.public_key.to_s == key.to_s
+      FileUtils.mkdir_p(File.dirname(SETTINGS.certificate_path))
+      File.open(SETTINGS.certificate_path, 'w') do |file|
+        file.print cert_s
+      end
 
-    ca_cert_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate/ca", 's', false)
-    ca_cert = OpenSSL::X509::Certificate.new(ca_cert_s)
-    raise "Certificate isn't signed by CA" unless cert.verify(ca_cert.public_key)
-    File.open(SETTINGS.ca_certificate_path, 'w') do |file|
-      file.print ca_cert_s
-    end
+      ca_cert_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate/ca", 's', false)
+      ca_cert = OpenSSL::X509::Certificate.new(ca_cert_s)
+      raise "Certificate isn't signed by CA" unless cert.verify(ca_cert.public_key)
+      File.open(SETTINGS.ca_certificate_path, 'w') do |file|
+        file.print ca_cert_s
+      end
 
-    ca_crl_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_revocation_list/ca", 's')
-    File.open(SETTINGS.ca_crl_path, 'w') do |file|
-      file.print ca_crl_s
+      ca_crl_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_revocation_list/ca", 's')
+      File.open(SETTINGS.ca_crl_path, 'w') do |file|
+        file.print ca_crl_s
+      end
+    rescue SocketError => e
+      raise SocketError, "Unable to contact CA server #{SETTINGS.ca_server}: #{e.message}"
     end
   end
 end


### PR DESCRIPTION
Tasks inside lib/tasks/install.rake could throw SocketErrors when
attempting to contact the CA server that did not give sufficient context
as to what connection was failing. This could let to the ultimately
unhelpful state of

(in /opt/puppet/share/puppet-dashboard)
rake aborted!
getaddrinfo: Name or service not known

This adds exception handling that will add the relevant context to the
exception and re-raise it. In this case, we would get

(in /opt/puppet/share/puppet-dashboard)
rake aborted!
Unable to contact ca_server example.unreachable.foo: getaddrinfo: Name or service not known

So when the task fails, there's a clear explanation for what exactly is
failing.
