### PR TITLE
(#12440) Add config flag to puppet-dashboard file in rh spec

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard.spec.erb
+++ b/ext/packaging/redhat/puppet-dashboard.spec.erb
@@ -114,7 +114,7 @@ fi
 %{initrddir}/puppet-dashboard
 %{initrddir}/puppet-dashboard-workers
 %config(noreplace) %{_sysconfdir}/sysconfig/puppet-dashboard
-%config(noreplace) %{_sysconfdir}/logrotate.d/puppet-dashboard
+%config %{_sysconfdir}/logrotate.d/puppet-dashboard
 %attr(-,puppet-dashboard,puppet-dashboard) %doc %{_datadir}/puppet-dashboard/VERSION
 %attr(-,puppet-dashboard,puppet-dashboard) %{_datadir}/puppet-dashboard/Rakefile
 %attr(-,puppet-dashboard,puppet-dashboard) %dir %{_datadir}/%{name}/config


### PR DESCRIPTION
Without this commit, the installer for dashboard treats the
/etc/sysconfig/puppet-dashboard config file as a regular file
and overwrites it during install, even if it already exists
and has been modified.  This patch marks puppet-dashboard in
the spec file as a config file, so that if it exists on the
install target and is modified, the original version is preserved.
