### PR TITLE
Add read-only access control hooks for Rack middleware

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   private
 
   def raise_if_enable_read_only_mode
-    raise ReadOnlyEnabledError.new if SETTINGS.enable_read_only_mode
+    raise ReadOnlyEnabledError.new if SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
   end
 
   def raise_unless_using_external_node_classification

--- a/app/views/node_classes/show.html.haml
+++ b/app/views/node_classes/show.html.haml
@@ -5,7 +5,7 @@
       Class:
       = @node_class.name
     %ul.actions
-      - unless SETTINGS.enable_read_only_mode
+      - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
         %li= link_to 'Edit', edit_node_class_path(@node_class), :class => "edit button"
         %li= link_to 'Delete', @node_class, :confirm => 'Are you sure?', :method => :delete, :class => "delete button"
 

--- a/app/views/node_groups/show.html.haml
+++ b/app/views/node_groups/show.html.haml
@@ -5,7 +5,7 @@
       Group:
       = @node_group.name
     %ul.actions
-      - unless SETTINGS.enable_read_only_mode
+      - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
         %li= link_to 'Edit', edit_node_group_path(@node_group), :class => "edit button", :rel => 'inspect'
         %li= link_to 'Delete', @node_group, :confirm => 'Are you sure?', :method => :delete, :class => "delete button"
 

--- a/app/views/nodes/show.html.haml
+++ b/app/views/nodes/show.html.haml
@@ -6,7 +6,7 @@
       Node:
       = h @node.name
       %span.alt= "(hidden)" if @node.hidden
-    - unless SETTINGS.enable_read_only_mode
+    - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
       %ul.actions
         %li= link_to 'Edit', edit_node_path(@node), :class => "edit button", :rel => 'inspect'
         - if @node.hidden

--- a/app/views/reports/_report.html.haml
+++ b/app/views/reports/_report.html.haml
@@ -1,7 +1,7 @@
 .header
   %h2
     = render 'report_title', :report => report
-  - unless SETTINGS.enable_read_only_mode
+  - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
     %ul.actions
       - Registry.each_callback :report, :actions do |thing|
         = thing.call self, report

--- a/app/views/shared/_node_manager_sidebar.html.haml
+++ b/app/views/shared/_node_manager_sidebar.html.haml
@@ -50,7 +50,7 @@
             = link_to "Hidden", hidden_nodes_path
 
   .footer.actionbar
-    - unless SETTINGS.enable_read_only_mode
+    - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
       = link_to "Add node", new_node_path, :class => 'button'
 
 = render "shared/node_manager_sidebar_for_type", :type => NodeGroup

--- a/app/views/shared/_node_manager_sidebar_for_type.html.haml
+++ b/app/views/shared/_node_manager_sidebar_for_type.html.haml
@@ -18,5 +18,5 @@
           = link_to entry.name, send(path_for_show, entry)
           %span.count= entry.nodes_count
   .footer.actionbar
-    - unless SETTINGS.enable_read_only_mode
+    - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
       = link_to "Add #{label.downcase}", send(path_for_new), :class => 'button'


### PR DESCRIPTION
Prior to this commit, Dashboard could be put into a read-only mode by
setting a flag in a configuration file. This commit extends this
ability to Rack middleware. Specfically, Rack middleware can put
Dashboard into read-only mode by declaring something like:

env['rack.session']['ACCESS_CONTROL_ROLE'] = 'READ_ONLY'

Prior to this commit, there were no tests for the read-only
configuration flag. This commit adds tests for both methods of making
Dashboard read-only. All tests pass. In addition, both read-only
methods have been tested in a live environment.
