### PR TITLE
(#12658) Add robots.txt to dashboard

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Without this patch, in the default install of puppet dashboard,
internet bots can crawl and index puppet dashboard sites.
This patch adds a robots.txt file to dashboard that prevents
crawling by all bot types of the whole site.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
