### PR TITLE
Update contributors in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,13 +45,42 @@ Thanks, Mark!
 Contributors
 ------------
 
-* Rein Henrichs <reinh@reinh.com>
-* Igal Koshevoy <igal@pragmaticraft.com>
-* Rick Bradley <rick@rickbradley.com>
-* Andrew Maier <andrew.maier@gatech.edu>
-* Scott Smith <scott@ohlol.net>
+* Adrien Thebo <adrien@puppetlabs.com>
+* Andreas Zuber <zuber@puzzle.ch>
+* Andrew Maier <dev+andrewmaier@hashrocket.com>
+* Bruno Leon <bruno.leon@savoirfairelinux.com>
+* Carl Caum <carl@carlcaum.com>
+* Chad Metcalf <chad@cloudera.com>
+* Chris W <cwacek@gmail.com>
+* Daniel Pittman <daniel@puppetlabs.com>
+* Daniel Sauble <djsauble@puppetlabs.com>
+* Danijel Ilisin <danijel.ilisin@sinnerschrader.com>
+* Devon Harless <devon@puppetlabs.com>
+* Evan Sparkman <evansparkman@esdezines.(none)>
 * Ian Ward Comfort <icomfort@stanford.edu>
-* Matt Robinson <matt@puppetlabs.com>
-* Nick Lewis <nick@puppetlabs.com>
+* Igal Koshevoy <igal@pragmaticraft.com>
 * Jacob Helwig <jacob@puppetlabs.com>
+* James Turnbull <james@puppetlabs.com>
+* Jesse Wolfe <jes5199@gmail.com>
+* Jonathan Grochowski <jonathan@puppetlabs.com>
+* Josh Cooper <josh@puppetlabs.com>
+* Joshua Harlan Lifton <lifton@puppetlabs.com>
+* Matt Robinson <matt@puppetlabs.com>
+* Matthaus Litteken <matthaus@puppetlabs.com>
+* Max Martin <max@puppetlabs.com>
+* Michael Stahnke <stahnma@puppetlabs.com>
+* Moses Mendoza <moses@puppetlabs.com>
+* Nick Fagerlund <nick.fagerlund@gmail.com>
+* Nick Lewis <nick@puppetlabs.com>
+* Nigel Kersten <nigel@puppetlabs.com>
+* Patrick Carlisle <patrick@puppetlabs.com>
 * Paul Berry <paul@puppetlabs.com>
+* Peter Meier <peter.meier@immerda.ch>
+* Pieter van de Bruggen <pieter@puppetlabs.com>
+* Randall Hansen <randall@puppetlabs.com>
+* Rein Henrichs <reinh@reinh.com>
+* Richard Clamp <richardc@unixbeard.net>
+* Rick Bradley <rick@rickbradley.com>
+* Rob <rob@ldg.net>
+* Saj Goonatilleke <sg@redu.cx>
+* Scott Smith <scott@ohlol.net>


### PR DESCRIPTION
It's been a long time since the contributors listed in the README.markdown were
updated, so this updates the contributors list based on the current git
history.
