### PR TITLE
Install a default settings.yml file with database.yml

### DIFF
--- a/ext/packaging/debian/rules
+++ b/ext/packaging/debian/rules
@@ -24,11 +24,13 @@ binary-install/puppet-dashboard::
 		VERSION \
 	    $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard
 	cp $(CURDIR)/config/database.yml.example $(CURDIR)/debian/$(cdbs_curpkg)/etc/puppet-dashboard/database.yml
+	cp $(CURDIR)/config/settings.yml.example $(CURDIR)/debian/$(cdbs_curpkg)/etc/puppet-dashboard/settings.yml
 	cp -r $(CURDIR)/public $(CURDIR)/debian/$(cdbs_curpkg)/var/$(cdbs_curpkg)
 	chmod -R a+rx $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/script
 	rm -rf $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/ext/packaging
 	# Clean up the "extra" files
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/config/database.yml.example
+	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/config/settings.yml.example
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/vendor/plugins/*/*LICENSE
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/vendor/plugins/*/License.txt
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/vendor/gems/*/*LICENSE

--- a/ext/packaging/redhat/puppet-dashboard.spec.erb
+++ b/ext/packaging/redhat/puppet-dashboard.spec.erb
@@ -51,6 +51,7 @@ install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/vendor
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_defaultdocdir}/%{name}-%{version}
 cp -p -r app bin config db ext lib public Rakefile script spec $RPM_BUILD_ROOT/%{_datadir}/%{name}
 install -Dp -m0644 config/database.yml.example $RPM_BUILD_ROOT/%{_datadir}/%{name}/config/database.yml
+install -Dp -m0644 config/settings.yml.example $RPM_BUILD_ROOT/%{_datadir}/%{name}/config/settings.yml
 install -Dp -m0644 VERSION $RPM_BUILD_ROOT/%{_datadir}/%{name}/VERSION
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/%{name}/spool
 


### PR DESCRIPTION
Currently dashboard installation lays down a database.yml
file by default. We supply an example settings file with
the package, this commit installs it as well.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
