### PR TITLE
create certs directory with installation

### DIFF
--- a/ext/packaging/debian/rules
+++ b/ext/packaging/debian/rules
@@ -7,7 +7,7 @@ ruby_ver = 1.8
 
 binary-install/puppet-dashboard::
 	mkdir -p $(CURDIR)/debian/$(cdbs_curpkg)/etc/puppet-dashboard
-	mkdir -p $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard
+	mkdir -p $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/certs
 	mkdir -p $(CURDIR)/debian/$(cdbs_curpkg)/var/$(cdbs_curpkg)/tmp
 	mkdir -p $(CURDIR)/debian/$(cdbs_curpkg)/var/log/puppet-dashboard
 	dh_installinit --name=puppet-dashboard-workers

--- a/ext/packaging/redhat/puppet-dashboard.spec.erb
+++ b/ext/packaging/redhat/puppet-dashboard.spec.erb
@@ -48,6 +48,7 @@ install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/log
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/public
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/tmp
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/vendor
+install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/certs
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_defaultdocdir}/%{name}-%{version}
 cp -p -r app bin config db ext lib public Rakefile script spec $RPM_BUILD_ROOT/%{_datadir}/%{name}
 install -Dp -m0644 config/database.yml.example $RPM_BUILD_ROOT/%{_datadir}/%{name}/config/database.yml
@@ -131,6 +132,7 @@ fi
 %attr(-,puppet-dashboard,puppet-dashboard) %dir %{_datadir}/%{name}/spool
 %attr(-,puppet-dashboard,puppet-dashboard) %dir %{_datadir}/%{name}/tmp
 %attr(-,puppet-dashboard,puppet-dashboard) %{_datadir}/%{name}/vendor
+%attr(-,puppet-dashboard,puppet-dashboard) %{_datadir}/%{name}/certs
 #%attr(-,puppet-dashboard,puppet-dashboard) %dir /var/log/%{name}
 
 %changelog


### PR DESCRIPTION
The installation doesn't create a certs directory
under /usr/share/puppet-dashboard, and thus generating
certs can be problematic because of permissions. This
commit adds the certs dir to installation and sets
ownership to puppet-dashboard.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
