### PR TITLE
(#11849) Add rake task to install cron job to clean up database reports

### DIFF
--- a/examples/puppet-dashboard.cleanup_reports.cron
+++ b/examples/puppet-dashboard.cleanup_reports.cron
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Example script to clean up after Dashboard by pruning old reports.
+# Options for the rake task specifying time requirements for report
+# deletion can be modified in this script. As specified below, this task will
+# delete reports older than one month. To view options for the task,
+# run `rake reports:prune` in the directory containing puppet-dashboard's
+# code.
+
+set -u
+
+PUPPET_DB_PATH=/usr/share/puppet-dashboard
+
+output=`rake -s -f ${PUPPET_DB_PATH}/Rakefile RAILS_ENV=production reports:prune upto=1 unit=mon 2>&1 1> /dev/null`
+if [ $? -ne 0 ]; then
+  logger -i "${output}"
+fi

--- a/ext/packaging/debian/rules
+++ b/ext/packaging/debian/rules
@@ -20,6 +20,7 @@ binary-install/puppet-dashboard::
 	    Rakefile \
 	    script \
 	    spec \
+      examples \
 	    vendor \
 		VERSION \
 	    $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard

--- a/ext/packaging/redhat/puppet-dashboard.spec.erb
+++ b/ext/packaging/redhat/puppet-dashboard.spec.erb
@@ -51,7 +51,8 @@ install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/vendor
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/certs
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_defaultdocdir}/%{name}-%{version}
 install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/spool
-cp -p -r app bin config db ext lib public Rakefile script spec vendor $RPM_BUILD_ROOT/%{_datadir}/%{name}
+install -p -d -m0755 $RPM_BUILD_ROOT/%{_datadir}/%{name}/examples
+cp -p -r app bin config db ext lib public Rakefile script spec examples vendor $RPM_BUILD_ROOT/%{_datadir}/%{name}
 install -Dp -m0640 config/database.yml.example $RPM_BUILD_ROOT/%{_datadir}/%{name}/config/database.yml
 install -Dp -m0640 config/settings.yml.example $RPM_BUILD_ROOT/%{_datadir}/%{name}/config/settings.yml
 install -Dp -m0644 VERSION $RPM_BUILD_ROOT/%{_datadir}/%{name}/VERSION
@@ -131,6 +132,7 @@ fi
 %attr(-,puppet-dashboard,puppet-dashboard) %dir %{_datadir}/%{name}/tmp
 %attr(-,puppet-dashboard,puppet-dashboard) %{_datadir}/%{name}/vendor
 %attr(-,puppet-dashboard,puppet-dashboard) %{_datadir}/%{name}/certs
+%attr(-,puppet-dashboard,puppet-dashboard) %{_datadir}/%{name}/examples
 #%attr(-,puppet-dashboard,puppet-dashboard) %dir /var/log/%{name}
 
 %changelog

--- a/lib/tasks/install_cleanup_cron.rake
+++ b/lib/tasks/install_cleanup_cron.rake
@@ -1,0 +1,16 @@
+require 'fileutils'
+namespace :cron do
+  desc 'Install monthly cron job to automatically prune old reports from the databases.'
+  task :cleanup do
+    cron_path      = '/etc/cron.monthly'
+    dashboard_path = '/usr/share/puppet-dashboard/examples'
+    cron_script    = 'puppet-dashboard.cleanup_reports.cron'
+
+    begin
+      ln_sf("#{dashboard_path}/#{cron_script}", "#{cron_path}/#{cron_script}")
+    rescue
+      puts "\n\nError: Could not create symlink #{cron_path}/#{cron_script}\n"
+      puts "Are you root?\n"
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a rake task to install a monthly cron
job to clean up old database reports, as suggested in official
Puppet Labs documentation. This allows users to easily install
the optional cron job while not risking undesired data loss for
those who do not wish to have the job installed by default.
