### PR TITLE
Updated debian packaging postinst script

### DIFF
--- a/ext/packaging/debian/postinst
+++ b/ext/packaging/debian/postinst
@@ -35,7 +35,7 @@ configure)
     find /etc/puppet-dashboard -type f -exec chmod a-x {} \;
 
     if [ ! -h /usr/share/puppet-dashboard/config/database.yml ]; then
-        ln -s ../../../../etc/puppet-dashboard/database.yml /usr/share/puppet-dashboard/config/database.yml
+        ln -s /etc/puppet-dashboard/database.yml /usr/share/puppet-dashboard/config/database.yml
     fi
     
     if [ ! -h /usr/share/puppet-dashboard/config/settings.yml ]; then


### PR DESCRIPTION
The settings.yml file was not linked from inside the puppet-dashboard/config directory and as a result dashboard and dashboard workers fail to start on debian systems (at least on Ubuntu lucid). This fixes that and also updates linking of database.yml to use absolute paths.

This should fix https://projects.puppetlabs.com/issues/15511.
