### PR TITLE
Filter Reports (index page) by status

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,10 +13,19 @@ class ReportsController < InheritedResources::Base
         if params[:kind] == "inspect"
           @reports = paginate_scope Report.inspections
         else
+          @controller_action = 'all'
           @reports = paginate_scope Report.applies
         end
       end
     end
+  end
+
+  [:all, :failed, :changed, :unchanged, :pending].each do |action|
+    define_method(action) {
+      @reports = paginate_scope Report.send(action)
+      @controller_action = action.to_s
+      render :index
+    }
   end
 
   def create

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -20,8 +20,13 @@ class Report < ActiveRecord::Base
 
   default_scope :order => 'time DESC', :include => :node
 
-  named_scope :inspections, :conditions => {:kind => "inspect"}, :include => :metrics
-  named_scope :applies,     :conditions => {:kind => "apply"  }, :include => :metrics
+  named_scope :inspections, :conditions => {:kind => "inspect"                       }, :include => :metrics
+  named_scope :applies,     :conditions => {:kind => "apply"                         }, :include => :metrics
+  named_scope :all,         :conditions => {:kind => "apply"                         }, :include => :metrics
+  named_scope :changed,     :conditions => {:kind => "apply", :status => 'changed'   }, :include => :metrics
+  named_scope :unchanged,   :conditions => {:kind => "apply", :status => 'unchanged' }, :include => :metrics
+  named_scope :failed,      :conditions => {:kind => "apply", :status => 'failed'    }, :include => :metrics
+  named_scope :pending,     :conditions => {:kind => "apply", :status => 'pending'   }, :include => :metrics
 
   def total_resources
     metric_value("resources", "total")

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -1,3 +1,4 @@
+- tab_statuses = Node.possible_statuses.unshift("all")
 #sidebar= render 'shared/node_manager_sidebar'
 #main
   .header
@@ -9,4 +10,8 @@
       %span.count== (#{@reports.total_entries})
 
   .item
+    %ul#report-tabs.tabbed
+      - tab_statuses.each do |tab_status|
+        %li{:id => "#{tab_status}-tab", :class => (tab_status == @controller_action ? 'active' : '')  }
+          %a{:href => "/reports/#{tab_status}"}= h tab_status.humanize
     = render 'reports/reports_table', :reports => @reports, :node => @node

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,12 @@ ActionController::Routing::Routes.draw do |map|
 
   map.resources :reports,
     :collection => {
-      :search => :get,
+      :search    => :get,
+      :all       => :get,
+      :failed    => :get,
+      :pending   => :get,
+      :changed   => :get,
+      :unchanged => :get
     }
 
   map.resources :node_group_memberships, :as => :memberships

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -5,6 +5,10 @@ require 'shared_behaviors/controller_mixins'
 describe ReportsController do
   before :each do
     @yaml = File.read(Rails.root.join('spec', 'fixtures', 'sample_report.yml'))
+    @failed = Report.create!(:host => "failed", :time => 1.week.ago.to_date, :status => "failed", :kind => "apply")
+    @unchanged = Report.create!(:host => "unchanged", :time => 1.week.ago.to_date, :status => "unchanged", :kind => "apply")
+    @pending = Report.create!(:host => "pending", :time => 1.week.ago.to_date, :status => "pending", :kind => "apply")
+    @changed = Report.create!(:host => "changed", :time => 1.week.ago.to_date, :status => "changed", :kind => "apply")
   end
 
   def model; Report end
@@ -86,6 +90,82 @@ describe ReportsController do
     end
   end
 
+  describe "#index" do
+    it "should render the index template and show all reports" do
+      get('index')
+      response.code.should == '200'
+      response.should render_template("reports/index")
+      assigns[:controller_action].should == 'all'
+      assigns[:reports].should include @failed
+      assigns[:reports].should include @pending
+      assigns[:reports].should include @changed
+      assigns[:reports].should include @unchanged
+    end
+  end
+
+  describe "#all" do
+    it "should render the index template and show all reports" do
+      get('all')
+      response.code.should == '200'
+      response.should render_template("reports/index")
+      assigns[:controller_action].should == 'all'
+      assigns[:reports].should include @failed
+      assigns[:reports].should include @pending
+      assigns[:reports].should include @changed
+      assigns[:reports].should include @unchanged
+    end
+  end
+
+  describe "#failed" do
+    it "should render the index template and show only failed reports" do
+      get('failed')
+      response.code.should == '200'
+      response.should render_template("reports/index")
+      assigns[:controller_action].should == 'failed'
+      assigns[:reports].should include @failed
+      assigns[:reports].should_not include @pending
+      assigns[:reports].should_not include @changed
+      assigns[:reports].should_not include @unchanged
+    end
+  end
+  describe "#pending" do
+    it "should render the index template and show only pending reports" do
+      get('pending')
+      response.code.should == '200'
+      response.should render_template("reports/index")
+      assigns[:controller_action].should == 'pending'
+      assigns[:reports].should_not include @failed
+      assigns[:reports].should include @pending
+      assigns[:reports].should_not include @changed
+      assigns[:reports].should_not include @unchanged
+    end
+  end
+  describe "#changed" do
+    it "should render the index template and show only changed reports" do
+      get('changed')
+      response.code.should == '200'
+      response.should render_template("reports/index")
+      assigns[:controller_action].should == 'changed'
+      assigns[:reports].should_not include @failed
+      assigns[:reports].should_not include @pending
+      assigns[:reports].should include @changed
+      assigns[:reports].should_not include @unchanged
+    end
+  end
+
+  describe "#unchanged" do
+    it "should render the index template and show only unchanged reports" do
+      get('unchanged')
+      response.code.should == '200'
+      response.should render_template("reports/index")
+      assigns[:controller_action].should == 'unchanged'
+      assigns[:reports].should_not include @failed
+      assigns[:reports].should_not include @pending
+      assigns[:reports].should_not include @changed
+      assigns[:reports].should include @unchanged
+    end
+  end
+
   describe "#search" do
     it "should render the search form if there are no parameters" do
       get('search')
@@ -153,5 +233,4 @@ describe ReportsController do
     @request.env.delete('RAW_POST_DATA')
     response
   end
-
 end


### PR DESCRIPTION
This pull request enables filtering of reports by the report's status.  

The UI is modeled after the similar functionality for filtering nodes by 'last run' status (tabs for 'changed', 'changed', 'unchanged', 'failed', 'etc').

Value:
I've often found myself wanting the ability to quickly find the last updates applied to the environment.  With our environment (that is fairly static most of the time), I spent quite a bit of time paging through unchanged reports before finding the last 'changed' report.
