### PR TITLE
(#15291) Add Vendor tag to Puppet-Dashboard spec file

### DIFF
--- a/ext/packaging/redhat/puppet-dashboard.spec.erb
+++ b/ext/packaging/redhat/puppet-dashboard.spec.erb
@@ -11,6 +11,7 @@ Release:        <%= release -%>%{?dist}
 Summary:        Systems Management web application
 Group:          Applications/System
 License:        ASL 2.0
+Vendor:         %{?_host_vendor}
 URL:            http://www.puppetlabs.com
 Source0:        http://yum.puppetlabs.com/sources/%{name}-%{realversion}.tar.gz
 BuildArch:      noarch


### PR DESCRIPTION
Previously the spec file had no Vendor tag, which left it undefined. This
commit adds a Vendor tag that references the _host_vendor macro, so that it can
be easily set to 'Puppet Labs' internally and customized by users easily. The
Vendor tag makes it easier for users to tell where the package came from.
