### PR TITLE
Fixes for generated links under phusion/apache

### DIFF
--- a/app/views/delayed_job_failures/index.html.haml
+++ b/app/views/delayed_job_failures/index.html.haml
@@ -7,9 +7,9 @@
   .item
     %ul.tabbed
       %li{ :class => active_if( controller.action_name == 'index' )}
-        = link_to "#{DelayedJobFailure.unread.count > 0 ? DelayedJobFailure.unread.count : ''} New failed tasks", '/delayed_job_failures'
+        = link_to "#{DelayedJobFailure.unread.count > 0 ? DelayedJobFailure.unread.count : ''} New failed tasks", "#{root_path}delayed_job_failures"
       %li{ :class => active_if( controller.action_name == 'read' )}
-        = link_to 'Previously-read failures', '/delayed_job_failures/read'
+        = link_to 'Previously-read failures', "#{root_path}delayed_job_failures/read"
 
     %div.panel.tabbed
       - if @delayed_job_failures.count > 0

--- a/app/views/shared/_node_manager_sidebar.html.haml
+++ b/app/views/shared/_node_manager_sidebar.html.haml
@@ -1,11 +1,11 @@
 - add_body_class 'with-sidebar'
 
 .group.delayed-job
-  %h3= link_to "Background Tasks", "/delayed_job_failures"
+  %h3= link_to "Background Tasks", "#{root_path}delayed_job_failures"
 
   - if DelayedJobFailure.unread.count > 0
     %p.failure
-      = link_to "#{ pluralize DelayedJobFailure.unread.count, 'new failed task' }", "/delayed_job_failures"
+      = link_to "#{ pluralize DelayedJobFailure.unread.count, 'new failed task' }", "#{root_path}delayed_job_failures"
   - if Delayed::Job.count > 0
     %p.warning
       %em= "#{ pluralize Delayed::Job.count, 'pending task' }"
@@ -50,7 +50,7 @@
 
   .footer.actionbar
     #radiator
-      = link_to "Radiator View", '/radiator'
+      = link_to "Radiator View", "#{root_path}radiator"
     - unless SETTINGS.enable_read_only_mode || session['ACCESS_CONTROL_ROLE'] == 'READ_ONLY'
       = link_to "Add node", new_node_path, :class => 'button'
 


### PR DESCRIPTION
Few links in the view templates where generated but possible root
path was not taken into account. This is fine if you ran dashboard
as standalone or in root folder of the phusion/apache but not when
dashboard had a folder prefix.
