### PR TITLE
Autorefresh link gen fixed to work under passenger

### DIFF
--- a/app/views/shared/_global_nav.html.haml
+++ b/app/views/shared/_global_nav.html.haml
@@ -31,4 +31,4 @@
         - Registry.each_callback :core, :account_widgets do |callback|
           = callback.call self
         %li#navigation-autorefresh
-          = link_to "#{session[:autorefresh] ? "Disable autorefresh" : "Enable autorefresh"}", "#{request.path}?autorefresh=#{session[:autorefresh] ? "false" : "true"}", :class => "autorefresh_link"
+          = link_to "#{session[:autorefresh] ? "Disable autorefresh" : "Enable autorefresh"}", "#{File.join(root_path,request.path)}?autorefresh=#{session[:autorefresh] ? "false" : "true"}", :class => "autorefresh_link"


### PR DESCRIPTION
Autorefresh link generation did not take root_path for the
application into consideration. Using File.join() to try and avoid
multiple /'s getting into generated url which would cause routing
problems.

Signed-off-by: Jani Mikkonen jani.mikkonen@gmail.com
