### PR TITLE
(#16333) Override function in AR MySQL connector to set sql_mode

### DIFF
--- a/config/initializers/mysql_session_sql_mode.rb
+++ b/config/initializers/mysql_session_sql_mode.rb
@@ -1,15 +1,11 @@
 module ActiveRecord::ConnectionAdapters
   class MysqlAdapter
+    alias :configure_connection_old :configure_connection
     def configure_connection
-      encoding = @config[:encoding]
-      execute("SET NAMES '#{encoding}'") if encoding
-      # By default, MySQL 'where id is null' selects the last inserted id.
-      # # Turn this off. http://dev.rubyonrails.org/ticket/6778
-
-      execute("SET SQL_AUTO_IS_NULL=0")
-
       # Explicitly set the SQL mode for the session in case there are problematic global settings
       execute("SET @@SESSION.sql_mode='TRADITIONAL'")
+
+      configure_connection_old()
     end
   end
 end


### PR DESCRIPTION
Currently if there is a problematic sql_mode set globally it will end up
breaking things. This patch overrides the configure_connection function
of the MySQL connector to explicitly set the sql_mode to traditional for
the session so that if something that breaks the queries used by the
console (like ANSI_QUOTES) is set globally, it won't affect it.
