### PR TITLE
fail better in package repo rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,31 +9,37 @@ require 'rake/testtask'
 require 'rdoc/task'
 
 require 'tasks/rails'
-require 'yaml'
 
 Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
-begin
-  @build_defaults ||= YAML.load_file('ext/build_defaults.yaml')
+
+build_defs_file = 'ext/build_defaults.yaml'
+if File.exist?(build_defs_file)
+  begin
+    require 'yaml'
+    @build_defaults ||= YAML.load_file(build_defs_file)
+  rescue Exception => e
+    STDERR.puts "Unable to load yaml from #{build_defs_file}:"
+    STDERR.puts e
+  end
   @packaging_url  = @build_defaults['packaging_url']
   @packaging_repo = @build_defaults['packaging_repo']
-rescue
-  STDERR.puts "Unable to read the packaging repo info from ext/build_defaults.yaml"
-end
+  raise "Could not find packaging url in #{build_defs_file}" if @packaging_url.nil?
+  raise "Could not find packaging repo in #{build_defs_file}" if @packaging_repo.nil?
 
-namespace :package do
-  desc "Bootstrap packaging automation, e.g. clone into packaging repo"
-  task :bootstrap do
-    if File.exist?("ext/#{@packaging_repo}")
-      puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
-    else
-      cd 'ext' do
-        %x{git clone #{@packaging_url}}
+  namespace :package do
+    desc "Bootstrap packaging automation, e.g. clone into packaging repo"
+    task :bootstrap do
+      if File.exist?("ext/#{@packaging_repo}")
+        puts "It looks like you already have ext/#{@packaging_repo}. If you don't like it, blow it away with package:implode."
+      else
+        cd 'ext' do
+          %x{git clone #{@packaging_url}}
+        end
       end
     end
-  end
-
-  desc "Remove all cloned packaging automation"
-  task :implode do
-    rm_rf "ext/#{@packaging_repo}"
+    desc "Remove all cloned packaging automation"
+    task :implode do
+      rm_rf "ext/#{@packaging_repo}"
+    end
   end
 end


### PR DESCRIPTION
This commit modifies the top level Rakefile to only
load the packaging repo yaml file if it exists, as
well as provide some error handling for other unwanted
conditions that may arise as a result of trying to
set up the packaging repo.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
