### PR TITLE
Specify favicon in error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -6,6 +6,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>The page you were looking for doesn't exist (404)</title>
+  <link href='/images/favicon.ico' rel='shortcut icon' />
 	<style type="text/css">
 		body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
 		div.dialog {

--- a/public/422.html
+++ b/public/422.html
@@ -6,6 +6,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>The change you wanted was rejected (422)</title>
+  <link href='/images/favicon.ico' rel='shortcut icon' />
 	<style type="text/css">
 		body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
 		div.dialog {

--- a/public/500.html
+++ b/public/500.html
@@ -6,6 +6,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>Puppet Dashboard encountered an error (500)</title>
+  <link href='/images/favicon.ico' rel='shortcut icon' />
 	<style type="text/css">
 		body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
 		div.dialog {


### PR DESCRIPTION
Prior to this commit, rendering an error page would itself result in an error if the default favicon.ico file is protected by an authentication system that has a whitelist of allowed routes.
