### PR TITLE
Make SQL status query more PostgreSQL-friendly.

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -35,17 +35,17 @@ class Status
     sql = <<-SQL
       SELECT
         COUNT(*)                                            as total,
-        SUM(CASE status when "unchanged" then 1 else 0 end) as unchanged,
-        SUM(CASE status when "changed" then 1 else 0 end)   as changed,
-        SUM(CASE status when "pending" then 1 else 0 end)   as pending,
-        SUM(CASE status when "failed" then 1 else 0 end)    as failed,
+        SUM(CASE status when 'unchanged' then 1 else 0 end) as unchanged,
+        SUM(CASE status when 'changed' then 1 else 0 end)   as changed,
+        SUM(CASE status when 'pending' then 1 else 0 end)   as pending,
+        SUM(CASE status when 'failed' then 1 else 0 end)    as failed,
         #{boundary_groupings}                               as start
       FROM reports
     SQL
 
     sql << "WHERE kind = 'apply'\n"
-    sql << "AND time < \"#{newest_accepatable_data.utc.to_s(:db)}\"\n"
-    sql << "AND time >= \"#{utc_date_boundaries.last.utc.to_s(:db)}\"\n"
+    sql << "AND time < '#{newest_accepatable_data.utc.to_s(:db)}'\n"
+    sql << "AND time >= '#{utc_date_boundaries.last.utc.to_s(:db)}'\n"
     sql << "AND node_id = #{options[:node].id}\n"                      if options[:node]
     sql << "AND node_id IN (#{options[:nodes].map(&:id).join(',')})\n" if options[:nodes].present?
     sql << "GROUP BY start\n"


### PR DESCRIPTION
Although Puppet Dashboard doesn't support PostgreSQL, there are already some pieces of code which adds support. In PostgreSQL strings are just single-quoted and the basic dashboard status query fails here:

```
ActionView::TemplateError (PGError: ERROR:  column "unchanged" does not exist
LINE 3:         SUM(CASE status when "unchanged" then 1 else 0 end) ...
                                     ^
:       SELECT
        COUNT(*)                                            as total,
        SUM(CASE status when "unchanged" then 1 else 0 end) as unchanged,
        SUM(CASE status when "changed" then 1 else 0 end)   as changed,
        SUM(CASE status when "pending" then 1 else 0 end)   as pending,
        SUM(CASE status when "failed" then 1 else 0 end)    as failed,
        CASE
WHEN time >= '2012-10-02 22:00:00' THEN '2012-10-03 00:00:00 +0200'
WHEN time >= '2012-10-01 22:00:00' THEN '2012-10-02 00:00:00 +0200'
...
```

Attached patch replaces double with single quotes in this query. Works with MySQL as well.
