### PR TITLE
(#9296) Fix loading rack for rubygems >= 1.8

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,6 +2,9 @@
 # Configure your app in config/environment.rb and config/environments/*.rb
 
 RAILS_ROOT = "#{File.dirname(__FILE__)}/.." unless defined?(RAILS_ROOT)
+Dir["#{RAILS_ROOT}/vendor/gems/**"].each do |dir|
+  $:.unshift(File.directory?(lib = "#{dir}/lib") ? lib : dir)
+end
 
 module Rails
   class << self

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -24,6 +24,9 @@ Rails::Initializer.run do |config|
 
   # Add additional load paths for your own custom dirs
   config.autoload_paths += %W( #{RAILS_ROOT}/app/mixins )
+  Dir["#{RAILS_ROOT}/vendor/gems/**"].each do |dir|
+    config.autoload_paths.unshift(File.directory?(lib = "#{dir}/lib") ? lib : dir)
+  end
 
   # Specify gems that this application depends on and have them installed with rake gems:install
   # config.gem "bj"

--- a/vendor/rails/actionpack/lib/action_controller.rb
+++ b/vendor/rails/actionpack/lib/action_controller.rb
@@ -31,7 +31,6 @@ rescue LoadError
   end
 end
 
-gem 'rack', '~> 1.1.0'
 require 'rack'
 require 'action_controller/cgi_ext'
 


### PR DESCRIPTION
Rubygems version 1.8 broke some of the ways vendored gems used to work in Rails
2. This commit updates the config/environment.rb to add all of the gem libs to
the rails autoload_paths and remove the explicit config.gem calls. It also
updates the actionpack action_controller library to not call out to gem
explicitly. We know that the correct rack version is being supplied in the
vendored gems, so the following require 'rack' line will succeed.
