### PR TITLE
Update debian and redhat init script to use INT instead of term to stop

### DIFF
--- a/ext/debian/init
+++ b/ext/debian/init
@@ -69,7 +69,7 @@ case $1 in
     ;;
     stop)
         log_daemon_msg "Stopping Puppet Dashboard"
-        if start-stop-daemon --stop --quiet --oknodo --pidfile ${PIDFILE} --user ${DASHBOARD_USER} --retry 10; then
+        if start-stop-daemon --stop --quiet --oknodo --signal INT --pidfile ${PIDFILE} --user ${DASHBOARD_USER} --retry 10; then
             log_end_msg 0
         else
             log_end_msg 1

--- a/ext/redhat/puppet-dashboard.init
+++ b/ext/redhat/puppet-dashboard.init
@@ -64,7 +64,7 @@ start() {
 
 stop() {
         echo -n $"Stopping Puppet Dashboard: "
-        killproc -p ${PIDFILE} puppet-dashboard
+        killproc -p ${PIDFILE} puppet-dashboard -INT
         RETVAL=$?
         if [ $RETVAL = 0 ]; then
             echo_success


### PR DESCRIPTION
Previously the debian init script didn't pass --signal to the
start-stop-daemon, which defaults to TERM. Dashboard runs out of webrick by
default, which catches and ignores TERM, but will respond to INT and stop
sanely. Currently, running `service puppet-dashboard stop` returns

[2012-03-27 10:24:17] ERROR SignalException: SIGTERM
    /usr/lib/ruby/1.8/webrick/server.rb:91:in `select'

and then waits for the retry timeout, at which point start-stop-daemon SIGKILLs
the ruby process. If --signal is set to INT in the init script, running
'service puppet-dashboard stop' returns

[2012-03-27 10:28:35] INFO  going to shutdown ...
[2012-03-27 10:28:35] INFO  WEBrick::HTTPServer#start done.
Exiting

which is the expected behavior.

The redhat init script suffered from a similar problem, adding -INT to the
killproc call speeds up the `service puppet-dashboard stop` call as killproc
doesn't need to wait and see if the process has ended, as INT is responded to
immediately by webrick.
