### PR TITLE
(maint) fix session killing

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -53,7 +53,7 @@ class ReportsController < InheritedResources::Base
   end
 
   def search
-    flash[:errors] = []
+    @errors = []
     inspected_resources = ResourceStatus.latest_inspections.order("nodes.name")
 
     @title = params[:file_title].to_s.strip
@@ -63,14 +63,14 @@ class ReportsController < InheritedResources::Base
       # Don't do anything; user just navigated to the search page
     else
       if !@title.present?
-        flash[:errors] << "Please specify the file title to search for"
+        @errors << "Please specify the file title to search for"
       end
       if !@content.present?
-        flash[:errors] << "Please specify the file content to search for"
+        @errors << "Please specify the file content to search for"
       elsif !is_md5?(@content)
-        flash[:errors] << "#{@content} is not a valid md5 checksum"
+        @errors << "#{@content} is not a valid md5 checksum"
       end
-      if flash[:errors].empty?
+      if @errors.empty?
         @matching_files = inspected_resources.by_file_title(@title).by_file_content(@content)
         @unmatching_files = inspected_resources.by_file_title(@title).without_file_content(@content)
       end

--- a/app/views/reports/search.html.haml
+++ b/app/views/reports/search.html.haml
@@ -6,10 +6,10 @@
       Search Latest Inspect Reports
 
   .item
-    - if flash[:errors].present?
+    - if @errors.present?
       %div{:class => "section error"}
         %h3 Errors
-        - flash[:errors].each do |messages|
+        - @errors.each do |messages|
           %p
             - messages.each do |message|
               %li= h message

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -123,7 +123,7 @@ describe ReportsController do
           get('search', :file_content => "ab07acbb1e496801937adfa772424bf7")
           assigns[:matching_files].should == nil
           assigns[:unmatching_files].should == nil
-          flash[:errors].should include "Please specify the file title to search for"
+          @errors.should include "Please specify the file title to search for"
         end
       end
 
@@ -132,7 +132,7 @@ describe ReportsController do
           get('search')
           assigns[:matching_files].should == nil
           assigns[:unmatching_files].should == nil
-          flash[:errors].should be_empty
+          @errors.should be_empty
         end
       end
 
@@ -141,7 +141,7 @@ describe ReportsController do
           get('search', :file_title => "", :file_content => "")
           assigns[:matching_files].should == nil
           assigns[:unmatching_files].should == nil
-          flash[:errors].should include "Please specify the file title to search for"
+          @errors.should include "Please specify the file title to search for"
         end
       end
     end


### PR DESCRIPTION
The misuse of the flash object was causing the session to be killed when
viewing the file search page.  This fixes it.
This supersedes #134
