### PR TITLE
(maint) fix failing report controller tests

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,6 +5,8 @@ class ReportsController < InheritedResources::Base
   before_filter :raise_if_enable_read_only_mode, :only => [:new, :edit, :update, :destroy]
   before_filter :handle_raw_post, :only => [:create, :upload]
 
+  attr_accessor :errors
+
   def index
     index! do |success,failure|
       success.html do

--- a/app/views/reports/search.html.haml
+++ b/app/views/reports/search.html.haml
@@ -6,10 +6,10 @@
       Search Latest Inspect Reports
 
   .item
-    - if @errors.present?
+    - if errors.present?
       %div{:class => "section error"}
         %h3 Errors
-        - @errors.each do |messages|
+        - errors.each do |messages|
           %p
             - messages.each do |message|
               %li= h message

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -123,7 +123,7 @@ describe ReportsController do
           get('search', :file_content => "ab07acbb1e496801937adfa772424bf7")
           assigns[:matching_files].should == nil
           assigns[:unmatching_files].should == nil
-          @errors.should include "Please specify the file title to search for"
+          subject.errors.should include "Please specify the file title to search for"
         end
       end
 
@@ -132,7 +132,7 @@ describe ReportsController do
           get('search')
           assigns[:matching_files].should == nil
           assigns[:unmatching_files].should == nil
-          @errors.should be_empty
+          subject.errors.should be_empty
         end
       end
 
@@ -141,7 +141,7 @@ describe ReportsController do
           get('search', :file_title => "", :file_content => "")
           assigns[:matching_files].should == nil
           assigns[:unmatching_files].should == nil
-          @errors.should include "Please specify the file title to search for"
+          subject.errors.should include "Please specify the file title to search for"
         end
       end
     end


### PR DESCRIPTION
Prior to this commit the reports controller specs were failing because
the instance variable @errors was not available to the spec tests. This
commit creates an accessor and uses that in place of the @errors
instance variable in the view and the specs.
