### PR TITLE
Now that we ship ruby 1.8.7, we can build for el5

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -9,7 +9,7 @@ gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-6-i386 fedora-15-i386 fedora-16-i386'
+final_mocks: 'pl-5-i386 pl-6-i386 fedora-15-i386 fedora-16-i386'
 rc_mocks: 'pl-6-i386-dev fedora-15-i386-dev fedora-16-i386-dev'
 yum_host: 'burji.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'


### PR DESCRIPTION
This commit adds a mock target for el5.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
