### PR TITLE
(#PE-339) Initialize pe_version to automate fact

### DIFF
--- a/config/initializers/pe_version_init.rb
+++ b/config/initializers/pe_version_init.rb
@@ -1,0 +1,27 @@
+# Retrieves the Puppet Enterprise version, and provides simple methods to present
+# the versioning information however it may be needed. Any repo should be able to
+# access these facts by passing a require File.join(File.dirname(_FILE_),
+# '../relative-path-to-src/puppet-dashboard/config/initializers/pe_version_init')
+
+def retrieve_pe_version
+  pe_version_fact     = File.read('/opt/puppet/pe_version').chomp
+  @pe_version_array   = pe_version_fact.split( '.' )
+  @pe_major_version   = @pe_version_array[0]
+  @pe_minor_version   = @pe_version_array[1]
+  pe_version_fact
+end
+
+def pe_major_version
+  retrieve_pe_version if @pe_major_version == nil
+  @pe_major_version
+end
+
+def pe_minor_version
+  retrieve_pe_version if @pe_mionor_version == nil
+  @pe_minor_version
+end
+
+def pe_version_major_minor
+  retrieve_pe_version if (@pe_major_version||@pe_mionor_version)== nil
+  "#{@pe_major_version}.#{@pe_minor_version}"
+end


### PR DESCRIPTION
Facter can be an inconsistent way to pass information, and can also
include a large overhead. This commit initializes a fact that is used in
several repos, the current major.minor pe_version.  This provides a
simple, centralized way to access this versioning information, which
also automates it when Facter facts are updated. The fact is read from a
file (/opt/puppet/pe_version), so changes to that path will require a
change in this initializer, pe_version_init.rb.

This PR goes along with  puppetlabs/pe_console_common#12
