### PR TITLE
'verb'! do |success, failure| is only for verbs create, update, destroy

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,8 +8,8 @@ class ReportsController < InheritedResources::Base
   attr_accessor :errors
 
   def index
-    index! do |success,failure|
-      success.html do
+    index! do |format|
+      format.html do
         if params[:kind] == "inspect"
           @reports = paginate_scope Report.inspections
         else


### PR DESCRIPTION
This is incorrect usage of inherited_resources bang verbs. The index! resource requires a block with one argument. Ruby 1.8 silently ignores this, but Ruby 1.9 gets very upset.  Only create!, update!, and destroy! may take blocks with arity 2.
