### PR TITLE
Call Metric.new instead of metrics.new

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -154,11 +154,11 @@ class Report < ActiveRecord::Base
 
   def add_missing_metrics
     ['pending', 'unchanged'].each do |additional_status|
-      next if metrics.detect {|m| m.category == 'resources' and m.name == additional_status }
-      metrics << metrics.new(
+      next if metrics.any? {|m| m.category == 'resources' and m.name == additional_status }
+      metrics << Metric.new(
         :category => 'resources',
         :name     => additional_status,
-        :value    => resource_statuses.select {|rs| rs.status == additional_status  }.length
+        :value    => resource_statuses.select {|rs| rs.status == additional_status }.length
       )
     end
   end


### PR DESCRIPTION
Calling `metrics.new` was duplicating all metrics, rather than only adding the one metric. Resolves this test failure:

```
  1) Report post transformer munging should idempotently update statuses and metrics
     Failure/Error: ]
       expected collection contained:  [["resources", "pending", 1], ["resources", "unchanged", 0]]
       actual collection contained:    [["resources", "pending", 1], ["resources", "pending", 1], ["resources", "unchanged", 0], ["resources", "unchanged", 0]]
       the extra elements were:        [["resources", "pending", 1], ["resources", "unchanged", 0]]
     # ./spec/models/report_spec.rb:103
```
