### PR TITLE
There are three retries in Report.create_from_yaml

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -422,7 +422,7 @@ describe Report do
 
       it "not unlink the file if create_from_yaml fails" do
         File.expects(:unlink).with('/tmp/foo').never
-        Report.expects(:create_from_yaml).raises(ActiveRecord::StatementInvalid)
+        Report.stubs(:create_from_yaml).raises(ActiveRecord::StatementInvalid)
         Report.create_from_yaml_file('/tmp/foo', :delete => true)
       end
 


### PR DESCRIPTION
Let the mock know it will be called three times. Resolves this test failure:

```
Failures:

  1) Report#create_from_yaml_file when create_from_yaml fails not unlink the file if create_from_yaml fails
     Failure/Error: Report.expects(:create_from_yaml).raises(ActiveRecord::StatementInvalid)
     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, invoked 3 times: Report(id: integer, node_id: integer, host: string, time: datetime, status: string, kind: string, puppet_version: string, configuration_version: string).create_from_yaml(any_parameters)
       satisfied expectations:
       - expected never, not yet invoked: File.unlink('/tmp/foo')
       - expected at least once, invoked 3 times: File.read('/tmp/foo')
     # ./spec/models/report_spec.rb:426

```
