### PR TITLE
Patch for CVE-2012-5664

### DIFF
--- a/vendor/rails/activerecord/lib/active_record/base.rb
+++ b/vendor/rails/activerecord/lib/active_record/base.rb
@@ -1897,7 +1897,11 @@ module ActiveRecord #:nodoc:
               # end
               self.class_eval <<-EOS, __FILE__, __LINE__ + 1
                 def self.#{method_id}(*args)
-                  options = args.extract_options!
+                  options = if args.length > #{attribute_names.size}
+                              args.extract_options!
+                            else
+                              {}
+                            end
                   attributes = construct_attributes_from_arguments(
                     [:#{attribute_names.join(',:')}],
                     args

--- a/vendor/rails/activerecord/test/cases/finder_test.rb
+++ b/vendor/rails/activerecord/test/cases/finder_test.rb
@@ -66,6 +66,18 @@ end
 class FinderTest < ActiveRecord::TestCase
   fixtures :companies, :topics, :entrants, :developers, :developers_projects, :posts, :comments, :accounts, :authors, :customers
 
+  def test_find_by_id_with_hash
+    assert_raises(ActiveRecord::StatementInvalid) do
+      Post.find_by_id(:limit => 1)
+    end
+  end
+
+  def test_find_by_title_and_id_with_hash
+    assert_raises(ActiveRecord::StatementInvalid) do
+      Post.find_by_title_and_id('foo', :limit => 1)
+    end
+  end
+
   def test_find
     assert_equal(topics(:first).title, Topic.find(1).title)
   end


### PR DESCRIPTION
Options hashes should only be extracted if there are extra parameters.

Further reading:
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-5664

https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-security/DCNTNp_qjFM

We may also need to remove/replace `config/initializers/session_store.rb` and require users to generate their own secret.
