### PR TITLE
A new implementation of jquery.placholders

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -6,6 +6,7 @@ var UNCHANGED    = '#093';
 var ALL          = '#000';
 
 jQuery(document).ready(function(J) {
+  J(":input[placeholder]").placeholder();
   J('table.main .status img[title]').tipsy({gravity: 's'});
 
   J('button.drop, a.drop').click( function(e) {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -637,3 +637,8 @@ body {
 
 a.autorefresh_link {
   color: #aaa; }
+
+.placeholder {
+  color: #aaa;
+}
+


### PR DESCRIPTION
The old implementation of placeholders was emulating placeholders even in browsers that natively support HTML5 placeholders.

I was testing 6 different implementations in 3 different browsers (2 with and 1 without HTML5 support). None of them was ideal so I chose the one that seemed to be the best to me (downloaded from https://github.com/andrewrjones/jquery-placeholder-plugin).

This has only one disadvantage for non-HTML5 browsers - it does not set placeholders on fields that are added dynamically (after the page is rendered). However, none of the implementations was able to do that anyway.

Another common problem of all other implementations was support for forms submitted with ajax - the placeholders were sent as values. For this one I found a workaround how to handle it: the HTTP post in the ajax form submit is called as an asynchronous operation after the submit handler returns control to the browser (implemented as a timer with zero delay). This way the jquery placeholder plugin removes placeholders before the form is serialized into the post request and everything works as expected. This is, however, something that is not a part of this PR since form ajaxification is a different issue but we should be prepared for that if we use it in future.
