### PR TITLE
Fix for CVE-2013-0155

### DIFF
--- a/vendor/rails/activerecord/lib/active_record/base.rb
+++ b/vendor/rails/activerecord/lib/active_record/base.rb
@@ -2340,6 +2340,8 @@ module ActiveRecord #:nodoc:
         def sanitize_sql_hash_for_conditions(attrs, default_table_name = quoted_table_name, top_level = true)
           attrs = expand_hash_conditions_for_aggregates(attrs)
 
+          return '1 = 2' if !top_level && attrs.is_a?(Hash) && attrs.empty?
+
           conditions = attrs.map do |attr, value|
             table_name = default_table_name
 


### PR DESCRIPTION
CVE-2013-0155 was originally stated to not affect ActiveRecord 2.3.x, but per this announcement: https://groups.google.com/group/rubyonrails-security/browse_thread/thread/73b8d3f8478df5e2, it does. This PR applies the patch supplied to the vendored rails in dashboard.
