### PR TITLE
(#17914) Store FlashHash as a normal Hash in session

### DIFF
--- a/config/initializers/01_serialize_flash_as_hash.rb
+++ b/config/initializers/01_serialize_flash_as_hash.rb
@@ -1,0 +1,48 @@
+# This is a backport of the patch: https://github.com/rails/rails/commit/36376560fdd02f955ae3bf6b7792b784443660ad
+# it allows other applications to unmarshal the session cookie without needing the full rails stack.
+#
+# Without this, applications that co-exist with puppet-aashboard (such as certificate service or live management)
+# will invalidate the session.
+module ActionController::Flash
+  class FlashHash
+    def self.from_session_value(value)
+      flash = case value
+              when FlashHash
+                new(::Hash[value], value.instance_variable_get(:@used))
+              when ::Hash
+                new(value['flash'], value['used'])
+              else
+                new
+              end
+      flash.sweep
+      flash
+    end
+
+    def to_session_value
+      return nil if empty?
+      {'flash' => ::Hash[self], 'used' => @used}
+    end
+
+    def initialize(flash = {}, used = {}) #:nodoc:
+      @used = {}
+      flash.each { |k,v| self[k] = v }
+      @used = used
+    end
+
+    def store(session, key = "flash")
+      return if self.empty?
+      session[key] = self.to_session_value
+    end
+  end
+
+  module InstanceMethods
+    def flash #:doc:
+      if !defined?(@_flash)
+        @_flash = FlashHash.from_session_value(session['flash'])
+        @_flash.sweep
+      end
+
+      @_flash
+    end
+  end
+end


### PR DESCRIPTION
This patch is a backport of:

https://github.com/rails/rails/commit/36376560fdd02f955ae3bf6b7792b784443660ad

In the form of a monkey patch in the puppet-dashboard initializer stage.

This is required to allow puppet-dashboard to co-exist with other applications
that do not have the full rails stack in their namespace. Without it, other
non-rails applications (such as the certificate service and live management)
are unable to unmarshal cookies created in Rails. Instead, they invalidate the
session and we start to see weird authentication glitches in the GUI.

In essence this patch ensures that when the FlashHash data is stored in a cookie
it is stored as a normal Ruby Hash, as apposed to an
ActionController::Flash::FlashHash. As all other Ruby applications should be
able to unmarshal a Hash, this will avoid the Marshal.load method in
Rack::Session::Cookie from throwing a NameError exception.

Signed-off-by: Ken Barber ken@bob.sh
