### PR TITLE
Change deprecated 'ftools' to 'fileutils'.

### DIFF
--- a/lib/tasks/plugins.rake
+++ b/lib/tasks/plugins.rake
@@ -1,5 +1,5 @@
 require 'pathname'
-require 'ftools'
+require 'fileutils'
 
 namespace :puppet do
   namespace :plugin do
@@ -16,7 +16,7 @@ namespace :puppet do
         else
           puts "Copying '#{source_file}' to '#{target_file}'."
           target_file.unlink if target_file.exist?
-          File.copy(source_file, target_file)
+          FileUtils.cp(source_file, target_file)
         end
       end
     end


### PR DESCRIPTION
'ftools' only work on Ruby 1.8, while 'fileutils' works on Ruby 1.8 and 1.9.

Good for older Rubies too ~~I don't know how far back in 1.8 'fileutils' is avaiable -- would need to check if it's a problem for 1.8.6 or 1.8.5, if you still support those?~~
