### PR TITLE
(maint) Make rails gems optional for rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,15 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
-require(File.join(File.dirname(__FILE__), 'config', 'boot'))
-require 'thread'
-
 require 'rake'
-require 'rake/testtask'
-require 'rdoc/task'
+require(File.join(File.dirname(__FILE__), 'config', 'boot'))
 
-require 'tasks/rails'
+["rake/testtask","rdoc/task","thread","tasks/rails"].each do |dependency|
+	begin
+		require dependency
+	rescue LoadError
+		puts "Could not load #{dependency}. Some rake tasks may not be available without #{dependency}."
+	end
+end
 
 Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }
 


### PR DESCRIPTION
Previously running rake -T without certain gems installed would trigger an
error such as "Could not find test-unit (= 1.2.3) amongst [facter-1.6.16,
json-1.7.5, json2graphite-0.0.7, munin-ruby-0.2.3, netaddr-1.5.0,
yam2g-0.0.1]". This gem (and others), shouldn't be necessary to run the
rakefile, list the tasks, or build packages. This commit addresses that by
iterating over the troublesome requires, rescuing any LoadErrors, and then
printing a message if the dependency could not be loaded.
This also removes a require on 'ftools' in the plugins raketask, as all of the
ftools methods have been moved to FileUtils, which is loaded with rake.
