### PR TITLE
(maint) Improve message during a load error in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,12 @@ require 'rake'
 require(File.join(File.dirname(__FILE__), 'config', 'boot'))
 
 ["rake/testtask","rdoc/task","thread","tasks/rails"].each do |dependency|
-	begin
-		require dependency
-	rescue LoadError
-		puts "Could not load #{dependency}. Some rake tasks may not be available without #{dependency}."
-	end
+  begin
+    require dependency
+  rescue LoadError => e
+    puts "Could not load #{dependency}. Some rake tasks may not be available without #{dependency}."
+    puts "The load error generated the following message: #{e.message}"
+  end
 end
 
 Dir['ext/packaging/tasks/**/*'].sort.each { |t| load t }


### PR DESCRIPTION
If the loading fails on "tasks/rails", it is generally because of a dependency
in one of the tasks. The current messaging won't give details of which require
failed in the task. This commit adds the message from the LoadError, which
gives details about which require failed.
