### PR TITLE
(#13486) Fix DJ doesn't work in a multi-server env

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -38,21 +38,8 @@ class ReportsController < InheritedResources::Base
 
   def upload
     begin
-      @@n ||= 0
-      yaml = params[:report][:report]
-      file = Rails.root + 'spool' + "report-#{$$}-#{@@n += 1}.yaml"
-
-      begin
-        fd = File.new(file, File::CREAT|File::EXCL|File::RDWR, 0600)
-        fd.print yaml
-        fd.close
-
-        Report.delay.create_from_yaml_file(file.to_s, :delete => true)
-        render :text => "Report queued for import as #{file.basename}"
-      rescue Errno::EEXIST
-        file = Rails.root + 'spool' + "report-#{$$}-#{@@n += 1}.yaml"
-        retry
-      end
+      Report.delay.create_from_yaml(params[:report][:report])
+      render :text => "Report queued for import"
     rescue => e
       error_text = "ERROR! ReportsController#upload failed:"
       Rails.logger.debug error_text


### PR DESCRIPTION
See:

http://projects.puppetlabs.com/issues/13486
http://projects.puppetlabs.com/issues/9409

This commit adds a patch written by Daniel Pittman and posted at https://gist.github.com/d023814313208dcc1978 but never merged.

It is the case that users want to deploy multiple instances of Puppet Dashboard and that this minor bug makes what would otherwise be a decently straightforward multi-instance deployment non-functional. The fix is simple. It's past due for this capability to be added out-of-box to product.
