### PR TITLE
(maint) Remove redundant filter_parameters

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,9 +39,6 @@ module PuppetDashboard
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 
-    # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
-
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 


### PR DESCRIPTION
Prior to this commit, the application config was trying to filter out
passwords from the logs twice. This didn't necessarily cause a problem,
but it's not needed twice. This commit removes the extra addition of
password to the filter_parameters.

/cc @sodabrew
