### PR TITLE
(maint) refactor SettingsReader expectations

### DIFF
--- a/spec/lib/settings_reader_spec.rb
+++ b/spec/lib/settings_reader_spec.rb
@@ -50,8 +50,7 @@ FILE
   it "should not output a warning if settings.yml defines all settings" do
     SettingsReader.stubs(:file_contents).with {|filename| File.basename(filename) == "settings.yml"}.returns(@settings_file_all)
     SettingsReader.stubs(:file_contents).with {|filename| File.basename(filename) == "settings.yml.example"}.returns(@sample_file)
-    ::Rails.logger.expects(:debug).with {|msg| msg !~ /Using default values/}
-    ::Rails.logger.expects(:debug).with {|msg| msg !~ /Using default values/}
+    ::Rails.logger.expects(:debug).with {|msg| msg !~ /Using default values/}.at_least_once
 
     SettingsReader.read.should == OpenStruct.new(
       "foo"                      => "bar",


### PR DESCRIPTION
Prior to this commit, when given a settings file, the test would call
.expects multiple times, once for each line that was sent to the logger.
This commit refactors those calls to add .at_least_once instead of
calling .expects multiple times.
