### PR TITLE
(maint) remove intermediate node object from tests

### DIFF
--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -21,8 +21,7 @@ describe NodesController do
       it "should return JSON" do
         struct = json_from_response_body
         struct.size.should == 1
-        # FIXME: why did I have to add ["node"] here?
-        struct.first["node"]["name"].should == @node.name
+        struct.first["name"].should == @node.name
       end
     end
 
@@ -189,8 +188,7 @@ describe NodesController do
         response.should be_success
 
         struct = json_from_response_body
-        # FIXME: why did I have to add ["node"] here?
-        struct["node"]["name"].should == @node.name
+        struct["name"].should == @node.name
       end
 
       it "should return an error for an unknown node" do


### PR DESCRIPTION
Prior to this commit, spec tests for Nodes controller were failing
because they still had the vestigal remains of the intermediate root
object in json. The actual implementation was changed in b3eac5d. This
commit removes the intermediate root object.

This is the source of the Travis test failures in GH-191.

/cc: @sodabrew @fhrbek
