### PR TITLE
(maint) fix node report footer

### DIFF
--- a/app/views/reports/_reports_table.html.haml
+++ b/app/views/reports/_reports_table.html.haml
@@ -18,7 +18,7 @@
   %tfoot
     - if defined?(reports)
       - if defined?(tfoot) and tfoot
-        = render :inline => tfoot, :locals => { :reports => reports, :node => node }
+        = render tfoot, :reports => reports, :node => node
       - else
         - if reports.total_pages > 1
           %tr


### PR DESCRIPTION
Prior to this commit, when a node had more than 10 reports, the node
detail page would have a `nodes/report_table_tfoot` blurb rather than
actually rendering that partial view. This commit alters the call to
`render` so that the partial view is dereferenced and rendered.

/cc: @sodabrew @fhrbek
