### PR TITLE
(maint) allow running w/ `RAILS_ENV=production`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'system_timer', :platforms => :ruby_18
 gem 'delayed_job', '~> 3.0'
 gem 'delayed_job_active_record', '~> 0.3.3'
 gem 'timeline_fu', '~> 0.3.0'
+gem 'haml', '~> 3.1.8'
 
 group :assets do
   gem 'sass-rails'    , '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ DEPENDENCIES
   execjs
   factory_girl (< 3.0)
   fastercsv
+  haml (~> 3.1.8)
   haml-rails (~> 0.3.5)
   inherited_resources (~> 1.0)
   jquery-rails (~> 2.1)

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,15 @@ Fast Install
 
 For detailed installation, setup, and usage instructions, see the [Puppet Dashboard 1.2 Manual](http://docs.puppetlabs.com/dashboard/manual/1.2).
 
+Production Environment
+----------------------
+
+Dashboard is currently configured to serve static assets when `RAILS_ENV=production`. In high-traffic
+environments, you may wish to farm this out to Apache or nginx.  Additionally, you must explicitly
+precompile assets for production using:
+ * `RAILS_ENV=production bundle exec rake assets:precompile` 
+
+
 Icons
 -----
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,7 +9,7 @@ PuppetDashboard::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS
   config.assets.compress = true


### PR DESCRIPTION
Prior to this commit, the rails 3 version of dashboard would not run in
production because of two problems:
1. bundler didn't know to look for the `haml` gem outside the `:assets`
   group
2. the production config explicitly didn't serve static assets (like
   images)

This commit adds the `haml` gem, already a dependency of the existing
`haml-rails` gem in the `:assets` group, but outside the `:assets` group for
availability after assets have been precompiled. This commit also allows
for serving static assets.
