### PR TITLE
Chart label formatting (conditional time format, shorter date format)

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -46,6 +46,7 @@ jQuery(document).ready(function(J) {
 
     var label_data = J(this).find("tr.labels th").mapHtml();
     var runtime_data = J(this).find("tr.runtimes td").mapHtmlFloat();
+    var format = "%" + (Math.max.apply(null, runtime_data) < 3 ? ".1f" : "d") + " s"; 
 
     J.jqplot(id, [runtime_data], {
       seriesColors: ["#009"],
@@ -82,7 +83,7 @@ jQuery(document).ready(function(J) {
           padMin: 0,
 
           tickOptions: {
-            formatString: '%.1f s'
+            formatString: format
           }
         }
       },

--- a/app/views/statuses/_run_failure.html.haml
+++ b/app/views/statuses/_run_failure.html.haml
@@ -13,7 +13,7 @@
     %thead
       %tr.labels
         - statuses.each do |status|
-          %th{:scope => :col}= status.start.strftime('%Y-%m-%d')
+          %th{:scope => :col}= status.start.strftime('%b-%d')
     %tbody
       %tr.unchanged
         - statuses.each do |status|


### PR DESCRIPTION
This is an attempt to make the chart labels user friendlier:

a) The dates in the stacked bar chart are displayed as 'Mon-DD' rather than 'YYYY-MM-DD'
b) The times in the line chart are displayed with 1 decimal if the total range is less than 3 or as integers if the total range is greater or equal to 3.

You can check the live demo (http://ec2-107-22-23-153.compute-1.amazonaws.com:3000/nodes) to see the results. There are 2 nodes, one has run times < 3, the other one > 3.
