### PR TITLE
Fix init script in Ubuntu/Debian and Redhat/Centos

### DIFF
--- a/ext/debian/init
+++ b/ext/debian/init
@@ -43,12 +43,13 @@ check_puppet_dashboard_status() {
 }
 
 start_puppet_dashboard() {
+    # Use start-stop-daemon to background the server and write the pidfile,
+    # instead of rails / webrick.
     start-stop-daemon --start --quiet --oknodo --make-pidfile --background --pidfile ${PIDFILE} --user ${DASHBOARD_USER} --chuid ${DASHBOARD_USER} --exec ${DASHBOARD_RUBY} -- ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE}
 
-    # This is a dirty, dirty hack, but it's rather difficult to get
-    # script/server to daemonize in any way, and still give us useful debugging
-    # output (or a real exit code) if it fails to start.
-
+    # Wait five seconds, then check if the pid is still valid,
+    # since start-stop-daemon returns success if the process is executed,
+    # but does not return an error if it exits right away.
     sleep 5
 
     check_puppet_dashboard_status

--- a/ext/redhat/puppet-dashboard.init
+++ b/ext/redhat/puppet-dashboard.init
@@ -39,10 +39,13 @@ start() {
             return 0
         fi
 
-        # This is a no longer a dirty, dirty hack, we now daemonize the server.
-        # Also: We have access to daemon.
+        # Use daemon to background the server and write the pidfile,
+        # instead of rails / webrick.
         daemon --user ${DASHBOARD_USER} --pidfile ${PIDFILE} "${DASHBOARD_RUBY} ${DASHBOARD_HOME}/script/server -e ${DASHBOARD_ENVIRONMENT} -p ${DASHBOARD_PORT} -b ${DASHBOARD_IFACE}"
 
+        # Wait five seconds, then check if the pid is still valid,
+        # since daemon returns success if the process is executed,
+        # but does not return an error if it exits right away.
         sleep 5
 
         check_status


### PR DESCRIPTION
Fix issue with wrong pidfile being created by start-stop-daemon.

Using -b on webrick makes it fork right after starting, leaving the pidfile created by start-stop-daemon pointing to a non-existing process. Removed -b so webrick woudn't fork.

On Ubuntu, using start-stop-daemon's --background switch instead.
On Redhat, relying on daemon's default behavior.
