### PR TITLE
Simplify the CSV aliasing adjust just for Ruby 1.8

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -128,7 +128,7 @@ class Node < ActiveRecord::Base
   end
 
   def self.to_csv_header
-    UseThisCSV.generate_line(Node.to_csv_properties + ResourceStatus.to_csv_properties)
+    CSV.generate_line(Node.to_csv_properties + ResourceStatus.to_csv_properties)
   end
 
   def self.to_csv_properties
@@ -147,7 +147,7 @@ class Node < ActiveRecord::Base
     end
 
     rows.map do |row|
-      UseThisCSV.generate_line row
+      CSV.generate_line row
     end.join
   end
 

--- a/lib/csv_extensions.rb
+++ b/lib/csv_extensions.rb
@@ -1,9 +1,9 @@
+# In Ruby 1.9 and up, FasterCSV is in stdlib and is called CSV.
 if RUBY_VERSION < '1.9'
   require 'fastercsv'
-  UseThisCSV = FasterCSV
+  CSV = FasterCSV
 else
   require 'csv'
-  UseThisCSV = CSV
 end
 
 class Array
@@ -21,7 +21,7 @@ class ActiveRecord::Base
   end
 
   def self.to_csv_header
-    UseThisCSV.generate_line to_csv_properties
+    CSV.generate_line to_csv_properties
   end
 
   def to_csv_array
@@ -29,6 +29,6 @@ class ActiveRecord::Base
   end
 
   def to_csv
-    UseThisCSV.generate_line to_csv_array
+    CSV.generate_line to_csv_array
   end
 end

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -60,10 +60,10 @@ describe NodesController do
 
     context "as CSV" do
       let :header do
-        UseThisCSV.generate_line %w[name            status            resource_count pending_count
-                                    failed_count    compliant_count   resource_type  title
-                                    evaluation_time file              line           time
-                                    change_count    out_of_sync_count skipped        failed ], :row_sep => ''
+        CSV.generate_line %w[name            status            resource_count pending_count
+                             failed_count    compliant_count   resource_type  title
+                             evaluation_time file              line           time
+                             change_count    out_of_sync_count skipped        failed ], :row_sep => ''
       end
 
       it "should make correct CSV" do
@@ -97,7 +97,7 @@ describe NodesController do
 
           response.should be_success
 
-          UseThisCSV.parse(response.body).last.first.should == name
+          CSV.parse(response.body).last.first.should == name
         end
       end
 


### PR DESCRIPTION
Instead of creating the alias class UseThisCSV, use plain CSV. Only for Ruby 1.8 override CSV with FasterCSV.
