### PR TITLE
No need to fully initialize Rails when precompiling assets

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,8 @@ module PuppetDashboard
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    # Don't load the entire application and database drivers just to run rake assets:precompile
+    config.assets.initialize_on_precompile = false
   end
 end


### PR DESCRIPTION
This change allows you to run `rake assets:precompile` without configuring a database. This will also be helpful at the packaging step.
