### PR TITLE
#15036 Prevent autorefresh on /search form pages too.

### DIFF
--- a/app/assets/javascripts/autorefresh.js
+++ b/app/assets/javascripts/autorefresh.js
@@ -3,8 +3,8 @@ jQuery(function($) {
 
   $('input#autorefresh').change(function() {
     // Prevent autorefresh on form pages
-    // TODO: Even better, prevent autorefresh when any form element has focus
-    if (/(new)|(edit)$/.test(window.location.pathname)) {
+    // TODO: In addition, prevent autorefresh when any form element has focus
+    if (/(new)|(edit)|(search)$/.test(window.location.pathname)) {
       $('span#autorefresh_countdown').html('&hellip;');
       $('li#navigation-autorefresh input').prop('disabled', true);
     } else if (this.checked) {


### PR DESCRIPTION
In addition to pages ending in new and edit, also halt the auto-refresh timer on search.
