### PR TITLE
Exclude existing items from autosuggest

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -298,3 +298,16 @@ function init_skiplink_target() {
     document.getElementById('skiplink').setAttribute("onclick" , "document.getElementById('skiptarget').focus();");
   }
 }
+
+function autosuggestResultFilter(class_id) {
+	return function(results) { 
+		var alreadyAssigned = jQuery(class_id).parent().find('.token-input-token-facebook p');
+		var myresults = results;
+		alreadyAssigned.each(function(i){
+			myresults = myresults.filter(function(element,index,array){ 
+				return alreadyAssigned[i].innerText != element.name;
+			});
+		});
+		return myresults;
+	};
+};

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -248,7 +248,7 @@ module ApplicationHelper
     inputs.each do |input|
       javascript << "  J('#{input[:class]}').tokenInput('#{input[:data_source]}', {\n"
       javascript << "    prePopulate: #{input[:objects].map {|object| {:id => object.id, :name => object.name}}.to_json},\n"
-      javascript << "    onResult: function(results) { var alreadyAssigned = J('#{input[:class]}').parent().find('.token-input-token-facebook p');\nvar myresults = results;\nalreadyAssigned.each(function(i){ myresults = myresults.filter(function(element,index,arry){ return alreadyAssigned[i].innerText != element.name;});}); return myresults;}\n"
+      javascript << "    onResult: autosuggestResultFilter('#{input[:class]}')"
       javascript << "  });\n"
     end
     javascript << "});"


### PR DESCRIPTION
Prior to this commit, the autosuggest box (for nodes, classes, groups)
would include already assigned elements in the suggestion dropdown. This
commit excludes the assigned elements from the query results when
searching for a new item.

NOTE: this implementation does still contain an edge case where a newly
assigned group may still be shown if the query has already been cached.
As a concrete example, groups `gamma` and `beta` have been assigned,
but `delta` and `alpha` have not. When `a` is typed into the group
assignment box, `delta` and `alpha` will be suggested. Assume `delta`
selected. When `a` is again typed, jquery.tokeninput plugin will notice
that the query results for `a` have already been cached and show them
again, both `delta` and `alpha` in this case even though `delta` was
assigned moments ago. This is a limitation in the jquery.tokeninput
plugin in that it allows custom code to be inject upon query results,
but not upon cache results. A separate un-cached query, such as `l` in
this case, will not exhibit this behaviour, resulting in only `alpha`
being suggested.
