### PR TITLE
Add setting disable_report_unchanged_events

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -130,6 +130,13 @@ class Report < ActiveRecord::Base
     report_hash["resource_statuses"] = report_hash["resource_statuses"].values
 
     report = Report.new(Report.attribute_hash_from(report_hash)).munge
+
+    # munge will capture metrics about the number of unchanged items
+    # then we can remove them to save space in the resource_statuses table
+    if SETTINGS.disable_report_unchanged_events
+      report.resource_statuses.delete_if {|rs| rs.status == 'unchanged' }
+    end
+
     report.save!
     report
   end

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -77,6 +77,10 @@ custom_logo_alt_text: 'Puppet Dashboard'
 # "http://dashboard_servername/reports/upload"
 disable_legacy_report_upload_url: false
 
+# Set this to true to prevent storing details about not-changed events
+# which saves a tremendous amount of space in the resource_statuses table.
+disable_report_unchanged_events: false
+
 # Disables the UI and controller actions for editing nodes, classes, groups and reports.  Report submission is still allowed
 enable_read_only_mode: false
 


### PR DESCRIPTION
This should resolve tracker issues #10987 and #12737 and many more complaining about the tremendous size of the resource_statuses table that's mostly full of "nothing changed" events.
