### PR TITLE
Make the tabs on the home and report pages bookmarkable.

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -220,6 +220,9 @@ jQuery(document).ready(function(J) {
   });
   J('.pages_home_action #home-tabs li:first').click();
 
+  // If there's a tab id in the location hash, click it!
+  J(window.location.hash).click();
+
   init_sidebar_links();
   init_skiplink_target();
 });

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -11,7 +11,7 @@
     %ul#home-tabs.tabbed
       - tab_statuses.each do |tab_status|
         %li(id="#{tab_status}-tab")
-          %a{:href => "#"}= h tab_status.humanize
+          %a{:href => "##{tab_status}-tab"}= h tab_status.humanize
     - tab_statuses.each do |tab_status|
       %div.panel(id = tab_status)
         = render 'nodes/nodes',

--- a/app/views/reports/_report.html.haml
+++ b/app/views/reports/_report.html.haml
@@ -13,11 +13,12 @@
   - panels = []
   %ul#report-tabs.tabbed
     - Registry.each_callback :core, :report_view_widgets do |name, widget|
+      - panel_id = user_facing[name].downcase
       - panels << capture_haml do
-        %div.panel(id="#{user_facing[name].downcase}")
+        %div.panel(id="#{panel_id}")
           = widget.call self, report
-      %li(id="#{user_facing[name].downcase}-tab")
-        %a= h user_facing[name]
+      %li(id="#{panel_id}-tab")
+        %a(href= "##{panel_id}-tab")= h user_facing[name]
   - panels.each do |panel|
     = raw panel
 


### PR DESCRIPTION
Hash identifiers are added to the tab hrefs on the home and reports pages, and a little javascript one-liner activates a tab if the hash matches.
