### PR TITLE
(packaging) Add vendor_gems pre_tar_task to dashboard

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -17,3 +17,4 @@ build_dmg: FALSE
 apt_host: 'burji.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
 apt_repo_path: '/opt/repository/incoming'
+pre_tar_task: 'package:vendor_gems'


### PR DESCRIPTION
The puppet-dashboard build will need to execute the vendor_gems pre-tar
task. This commit adds this to the build_defaults.yaml file.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
