### PR TITLE
(maint) add a javascript runtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :assets do
   gem 'sass-rails'    , '~> 3.2'
   gem 'haml-rails'    , '~> 0.3.5'
   gem 'jquery-rails'  , '~> 2.1'
+  gem 'therubyracer'
   gem 'uglifier'      , '~> 1.0'
   gem 'execjs' # Will use system-available JS runtime
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.7.7)
     json_pure (1.7.7)
+    libv8 (3.11.8.17)
     mail (2.5.3)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -102,6 +103,7 @@ GEM
     rake (0.9.6)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.4)
     responders (0.9.3)
       railties (~> 3.1)
     rspec (2.13.0)
@@ -137,6 +139,9 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.7)
     system_timer (1.2.4)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -180,6 +185,7 @@ DEPENDENCIES
   shoulda-matchers
   sqlite3
   system_timer
+  therubyracer
   thin
   timeline_fu (~> 0.3.0)
   uglifier (~> 1.0)


### PR DESCRIPTION
Prior to this commit, Rails used the execjs gem for the asset
precompilation; however, some platforms, like Linux, don't have a
default JavaScript runtime available. The commit adds a gem dependency
on `therubyracer` which uses the v8 engine embedded in the `libv8` gem.
