### PR TITLE
Set verify_mode explicitly in puppet_https.rb

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -6,6 +6,7 @@ class PuppetHttps
     connection = Net::HTTP.new(url.host, url.port)
     connection.use_ssl = true
     if authenticate
+      connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
       certpath = File.join(Rails.root, SETTINGS.certificate_path)
       pkey_path = File.join(Rails.root, SETTINGS.private_key_path)
       if File.exists?(certpath)
@@ -14,6 +15,8 @@ class PuppetHttps
       if File.exists?(pkey_path)
         connection.key = OpenSSL::PKey::RSA.new(File.read(pkey_path))
       end
+    else
+      connection.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
     connection.start { |http| http.request(req) }
   end


### PR DESCRIPTION
In Ruby 1.8, Net::HTTP defaulted to SSL::VERIFY_NONE, which meant that the CA
was never verified when submitting the CSR to the puppetmaster/ca. In Ruby 1.9,
the default changed to SSL::VERIFY_PEER, which means that without the CA cert,
the initial CSR cannot be submitted.
The make_ssl_request method in puppet_https.rb takes an authenticate argument,
but the verify_mode was never set to match this parameter.
This commit adds a patch to puppet_https that sets VERIFY_NONE explicitly when
authenticate is set to false in the method, and also sets it explicitly to
VERIFY_PEER when authenticate is set to true. This sets explicitly what was
previously trusted implicitly in the ruby version.
