### PR TITLE
Use the ca_certificate_path when it exists to verify

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -7,8 +7,12 @@ class PuppetHttps
     connection.use_ssl = true
     if authenticate
       connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      ca_file = File.join(Rails.root, SETTINGS.ca_certificate_path)
       certpath = File.join(Rails.root, SETTINGS.certificate_path)
       pkey_path = File.join(Rails.root, SETTINGS.private_key_path)
+      if File.exists?(ca_file)
+        connection.ca_file = ca_file
+      end
       if File.exists?(certpath)
         connection.cert = OpenSSL::X509::Certificate.new(File.read(certpath))
       end


### PR DESCRIPTION
In the install.rake cert:retrieve method the CA certificate is downloaded and
available to verify future connections to the CA. If the file exists, it should
be used to verify connections when authenticate is true, otherwise the
connections will fail. This commit adds the ca_file to the net http connection
if the ca_certificate_path exists.
