### PR TITLE
(#5927) Change Reports urls to be relative with use of ActionController::Base.relative_url_root setting

### DIFF
--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -14,7 +14,7 @@
       - tab_statuses.each do |tab_status|
         %li{:id => "#{tab_status}-tab", :class => (tab_status == @controller_action ? 'active' : '')  }
           - if tab_status == 'all'
-            %a{:href => '/reports'}= h tab_status.humanize
+            %a{:href => "#{ActionController::Base.relative_url_root}/reports"}= h tab_status.humanize
           - else
-            %a{:href => "/reports/#{tab_status}"}= h tab_status.humanize
+            %a{:href => "#{ActionController::Base.relative_url_root}/reports/#{tab_status}"}= h tab_status.humanize
     = render 'reports/reports_table', :reports => @reports, :node => @node


### PR DESCRIPTION
when installing puppet dashboard in a different path then the root url (e.g http://<host>/puppet-dash/ ), when accessing the Reports, the link will redirect back to /reports instead of <different path>/reports (e.g http://<host>/reports instead of http://<host>/puppet-dash/reports) and will return a 404. this fix prepend the ActionController::Base.relative_url_root  to the Reports href and therefor return the correct url.
