### PR TITLE
Fixing autorefresh for https urls, with apache proxy in front

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %link{ :href => image_path("favicon.ico"), :rel => "shortcut icon" }
     %meta{ :content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type" }
     - if session[:autorefresh]
-      %meta{ :content => "5; URL=#{request.url}", "http-equiv" => "refresh" }
+      %meta{ :content => "5; URL=#{request.env['SCRIPT_NAME']}", "http-equiv" => "refresh" }
 
     = javascript_include_tag 'jquery.min'
     :javascript


### PR DESCRIPTION
When you have an apache with a https vhost in front - autofresh does not work - as the request.url is being set to http://$url - ie. wrong scheme :(

I fixed it by using a relative URL for the refresh instead.
