### PR TITLE
(PE-507) Modify nodegroup:parameters to allow comma and equal signs

### DIFF
--- a/lib/tasks/classesgroups.rake
+++ b/lib/tasks/classesgroups.rake
@@ -137,8 +137,13 @@ namespace :nodegroup do
       exit
     end
 
-    given_parameters = Hash[ ENV['parameters'].split(',').map do |param|
-      param_array = param.split('=',2)
+    #We do a ton of reversing here, because Ruby 1.8 doesn't have lookbehind
+    given_parameters = Hash[ ENV['parameters'].reverse.split(/,(?!\\)/).map do |param|
+      param_array = param.split(/=(?!\\)/,2).map do |reverse_element|
+        reverse_element.reverse.gsub('\\=', '=').gsub('\\,', ',')
+      end
+
+      param_array.reverse!
       if param_array.size != 2
         raise ArgumentError, "Could not parse parameter #{param_array.first} given. Perhaps you're missing a '='"
       end


### PR DESCRIPTION
Previously, commas and equal signs could not be used in parameters
passed to the nodegroup:parameters rake job, even when escaped, as
the task did a simple split on the , and = characters. This commit
modifies the behavior to only split on un-escaped chars.

One oddity is that we reverse the array and its contents a few times
to get at this material. This is because Ruby 1.8 has no backreferences
in regular expressions. Once all 1.8 support is dropped we can use
a much simpler regular expression - ,(?!\) - rather than the gyrations
we go through here.
