### PR TITLE
display newlines as newlines in code or pre elements, e.g. Report Log

### DIFF
--- a/public/stylesheets/typography.css
+++ b/public/stylesheets/typography.css
@@ -73,6 +73,7 @@ strong {
 
 code, pre {
   font-family: "Monaco", "Courier New", Courier, fixed-width;
+  white-space: pre;
 }
 
 p.error {


### PR DESCRIPTION
Makes puppet dashboard with show_diff = true in puppet.conf more usable.

Could otherwise be more specifically added in application.scss inside of tr.puppet_log { }
