### PR TITLE
ext/redhat/puppet-dashboard-workers.init: make one worker status work

### DIFF
--- a/ext/redhat/puppet-dashboard-workers.init
+++ b/ext/redhat/puppet-dashboard-workers.init
@@ -60,7 +60,7 @@ restart() {
 
 rh_status() {
 	RETVAL=1
-	for pidfile in $(ls -1 "${DASHBOARD_HOME}"/tmp/pids/delayed_job.*.pid 2>/dev/null)
+	for pidfile in $(ls -1 "${DASHBOARD_HOME}"/tmp/pids/delayed_job.*pid 2>/dev/null)
 	do
 		status -p $pidfile puppet-dashboard-workers || return $?
 		RETVAL=$?


### PR DESCRIPTION
Make '/etc/init.d/puppet-dashboard-workers status' work in RedHat
environment when there is only one dashboard worker.  The exact issue
is that pid files are numbered when there are multiple of them, but
single worker pid file has no number in it's name.

The fix is similar to Bruno Leon's debian fix from commit in reference.

References: b44806771c527c9faa36fc8f3968b5996adb87e2
Signed-off-by: Sami Kerola kerolasa@iki.fi
