### PR TITLE
Created work around for pidfile problem with debian init.d script

### DIFF
--- a/ext/debian/init
+++ b/ext/debian/init
@@ -51,7 +51,10 @@ start_puppet_dashboard() {
     # since start-stop-daemon returns success if the process is executed,
     # but does not return an error if it exits right away.
     sleep 5
-
+    # Due to an issue of cascading processes being started up, the pid file 
+    # becomes invalid as the process that was started 
+    # does not remain as the ongoing running process
+    ps -ef | grep puppet-dashboard | grep -v grep | awk '{print $2}' > ${PIDFILE}
     check_puppet_dashboard_status
 }
 


### PR DESCRIPTION
created work around for debian pidfile to which currently will contain the incorrect pid for running process which results in false failed start and does not allow for puppet to ensure running
