### PR TITLE
Changed comment from inline

### DIFF
--- a/ext/passenger/dashboard-vhost.conf
+++ b/ext/passenger/dashboard-vhost.conf
@@ -64,7 +64,8 @@ RailsAutoDetect On
 #       AuthName "Puppet Dashboard"
 #       Require valid-user
 #       AuthBasicProvider file
-#       AuthUserFile /etc/apache2/passwords # Change to your preferred password file location
+#       # Change to your preferred password file location
+#       AuthUserFile /etc/apache2/passwords 
 #   </Location>
 
 </VirtualHost>


### PR DESCRIPTION
Apache complained `AuthUserFile takes 1-2 arguments, text file containing user IDs and passwords`. It took me longer than I'd have like to figure out the inline comment was causing the problem. Hopefully this will save another noob some time. 
