### PR TITLE
Improved the rendering layout of the report page

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -650,17 +650,33 @@ body {
         th.log_level {
           width: 4em;
         }
-        th.source {
-          width: 20%;
-        }
-        th.file {
-          width: 15%;
+        th.message {
+          min-width: 30%;
         }
         th.line {
-          width: 4em;
+          width: 2em;
         }
-        th.time {
-          width: 12em;
+        @media screen and (min-width: 1024px) {
+          th.source {
+            width: 20%;
+          }
+          th.file {
+            width: 15%;
+          }
+          th.time {
+            width: 12em;
+          }
+        }
+        @media screen and (max-width: 1023px) {
+          th.source {
+            width: 12%;
+          }
+          th.file {
+            width: 12%;
+          }
+          th.time {
+            width: 8%
+          }
         }
       }
       tbody {

--- a/app/views/puppet/util/logs/_log.haml
+++ b/app/views/puppet/util/logs/_log.haml
@@ -7,5 +7,4 @@
   %td.wrap= h wrap_on_slashes(log.source)
   %td.wrap= h wrap_on_slashes(log.file)
   %td.wrap= h log.line
-  %td.nowrap
-    %code= h log.time
+  %td.wrap= h log.time

--- a/app/views/reports/_log.html.haml
+++ b/app/views/reports/_log.html.haml
@@ -6,7 +6,7 @@
         %thead
           %tr
             %th.log_level{:scope => :col} Level
-            %th{:scope => :col} Message
+            %th.message{:scope => :col} Message
             %th.source{:scope => :col} Source
             %th.file{:scope => :col} File
             %th.line{:scope => :col} Line


### PR DESCRIPTION
This pull request improves the look of the report log page by preserving white-space and new-lines in the report log message. The table is now fixed to the width of the screen to ensure that nothing will extend off of the screen. To combat issues with small screens, columns width will now dynamically scale to expand to the entire screen.
