### PR TITLE
Fix the truncating in reports details if they fail

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -135,9 +135,9 @@ class Report < ActiveRecord::Base
     # 2) the TEXT field type has a maximum length of 64 KB
     # (Go through some contortions to avoid copying 64+ KB)
     details = e.to_s
-    details.slice!(65535)
+    details.slice!(0, 65535) if details.length > 65535
     backtrace = Rails.backtrace_cleaner.clean(e.backtrace)
-    backtrace.slice!(65535)
+    backtrace.slice!(0, 65535) if backtrace.length > 65535
 
     DelayedJobFailure.create!(
       :summary   => "Importing report",


### PR DESCRIPTION
The current implementation will only cut a single char at the position 65535 and not actually truncate the string. This patch will fix the issue.
