### PR TITLE
Revert "Include name in the group by to allow the field to be sorted"

### DIFF
--- a/app/models/node_class.rb
+++ b/app/models/node_class.rb
@@ -27,7 +27,7 @@ class NodeClass < ActiveRecord::Base
       LEFT OUTER JOIN node_class_memberships ON (node_classes.id = node_class_memberships.node_class_id)
       LEFT OUTER JOIN nodes ON (nodes.id = node_class_memberships.node_id)
     SQL
-    :group => 'node_classes.id, node_classes.name'
+    :group => 'node_classes.id'
 
   def to_param
     SETTINGS.numeric_url_slugs ? id.to_s : name

--- a/app/models/node_group.rb
+++ b/app/models/node_group.rb
@@ -39,7 +39,7 @@ class NodeGroup < ActiveRecord::Base
       LEFT OUTER JOIN node_group_memberships ON (node_groups.id = node_group_memberships.node_group_id)
       LEFT OUTER JOIN nodes ON (nodes.id = node_group_memberships.node_id)
     SQL
-    :group => 'node_groups.id, node_groups.name'
+    :group => 'node_groups.id'
 
   assigns_related :node_class, :node_group, :node
 


### PR DESCRIPTION
This reverts commit c7448ab4cfd38c790e5fd0652e225d217e754edd.

Per #276 and #282, in PostgreSQL 8.4 you cannot SELECT columns not mentioned in a GROUP BY unless they are used in an aggregate function. In PostgreSQL 9.0 and above, you may have ungrouped columns in the SELECT clause if the GROUP BY is a unique column.

MySQL has supported this behavior for a long time. It goes one step further, and doesn't even require that the GROUP BY be unique, MySQL will just grab any old row nondeterministically. This is very convenient and supremely frightening ;)

The query in question requires the unique-row GROUP BY behavior, or the query has to be greatly restructured. The interest for supporting this is to use the stock Pg 8.4 in RHEL 6.

At this time I cannot provide support for Pg < 9.0.
