### PR TITLE
Fixes bug in parsing report from agent versions ~> 2.6

### DIFF
--- a/lib/report_transformer.rb
+++ b/lib/report_transformer.rb
@@ -15,7 +15,7 @@ end
 
 class ReportTransformer::ReportTransformation
   def self.apply(report)
-    return report if report["report_format"] >= version
+    return report if report["report_format"] and report["report_format"] >= version
 
     transform(report)
 


### PR DESCRIPTION
Without this patch, puppet dashboard workers cannot parse reports from old agents (e.g.: Debian Squeeze's Version 2.6.2-5+squeeze9).

I got this error in form the workers 

```
Worker(delayed_job host:admin1 pid:9870)] Class#create_from_yaml failed with NoMethodError: undefined method `>=' for nil:NilClass
```

With the fix from this PR everything is working fine

[Compare puppet-dasboard-wip Issue #18](https://github.com/sodabrew/puppet-dashboard-wip/issues/18)
