### PR TITLE
Set status to "failed" if the log contains errors

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -191,6 +191,7 @@ class Report < ActiveRecord::Base
   def recalculate_report_status
     self.status = 'pending' if resource_statuses.any? {|rs| rs.status == 'pending' } &&
       resource_statuses.none? {|rs| rs.status == 'failed'}
+    self.status = 'failed' if self.logs.any? {|l| l.level == 'err' } 
   end
 
   def add_missing_metrics


### PR DESCRIPTION
If there is an error during catalog compilation, but the agent uses the cached catalog, then dashboard will not show the error when the run was successful.
