### PR TITLE
Change report and delayed jobs to binary blobs

### DIFF
--- a/db/migrate/20140414051338_change_reports_to_blobs.rb
+++ b/db/migrate/20140414051338_change_reports_to_blobs.rb
@@ -1,13 +1,15 @@
 class ChangeReportsToBlobs < ActiveRecord::Migration
   def up
     if ActiveRecord::Base.connection.adapter_name.downcase =~ /postgres/
+      # bytea columns are unlimited
       change_column :resource_events, :message, 'bytea USING message::bytea'
       change_column :delayed_jobs, :handler, 'bytea USING handler::bytea'
       change_column :delayed_job_failures, :details, 'bytea USING details::bytea'
     else
-      change_column :resource_events, :message, :binary
-      change_column :delayed_jobs, :handler, :binary
-      change_column :delayed_job_failures, :details, :binary
+      # Lenghts > 16MB are LONGBLOB
+      change_column :resource_events, :message, :binary, :limit => 20.megabyte
+      change_column :delayed_jobs, :handler, :binary, :limit => 20.megabyte
+      change_column :delayed_job_failures, :details, :binary, :limit => 20.megabyte
     end
   end
 


### PR DESCRIPTION
Per #273, #274, #286 let's change the report columns to binary blobs instead of text fields. This may require some direct SQL, but let's try doing it "rails native" first.
