### PR TITLE
update only parts of the radiator

### DIFF
--- a/app/assets/javascripts/radiator.js
+++ b/app/assets/javascripts/radiator.js
@@ -44,7 +44,7 @@ jQuery(function($) {
       if (refresh_count == 1) {
         $('span#status').html('&hellip;');
       } else if (refresh_count == 0) {
-        $.ajax(window.location)
+        $.getJSON(window.location)
           .done(function(data) {
             for(var key in data) {
               var row = $('tr.' + key);

--- a/app/assets/stylesheets/radiator.scss
+++ b/app/assets/stylesheets/radiator.scss
@@ -69,6 +69,7 @@ body.radiator_controller {
           left : 0;
           height: 100%;
           overflow: hidden;
+          transition: width 1s;
 
           span {
             margin-left: 0.1em;

--- a/app/views/layouts/_radiator.html.haml
+++ b/app/views/layouts/_radiator.html.haml
@@ -3,7 +3,7 @@
   %head
     - page_title = yield(:page_title)
     %title= 'Puppet Node Manager'
-    %meta{"http-equiv" => "refresh", :content => "60"}
+    %meta{"http-equiv" => "refresh", :content => 30.minutes}
     = stylesheet_link_tag 'application.radiator'
     = javascript_include_tag 'application.radiator'
 


### PR DESCRIPTION
Currently the radiator basically reloads the whole page on every
refresh, leading to an irritating flicker.

Now we actually request JSON from the server instead of the normal HTML
page. We still update the page every 30 minutes to propagate HTML
changes to long running monitors.

To avoid more distraction, we animate the radiator percentages.
