### PR TITLE
Fix report sanitization for new report types

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -10,7 +10,7 @@ class Report < ActiveRecord::Base
 
   accepts_nested_attributes_for :logs, :metrics, :resource_statuses, :events
 
-  attr_accessible :host, :time, :status, :kind, :puppet_version, :configuration_version
+  attr_accessible :host, :time, :status, :kind, :puppet_version, :configuration_version, :environment
   attr_accessible :logs_attributes, :metrics_attributes, :resource_statuses_attributes, :events_attributes
 
   before_validation :assign_to_node
@@ -77,14 +77,14 @@ class Report < ActiveRecord::Base
 
   def self.attribute_hash_from(report_hash)
     attribute_hash = report_hash.dup
-    
+
     # message could grow larger than what database column size allow.
     attribute_hash["logs_attributes"] = attribute_hash.delete("logs")
     attribute_hash["logs_attributes"].each do |resource_logs_hash|
       log_message = resource_logs_hash["message"].to_s
       resource_logs_hash["message"] = log_message.slice(0, 65535) if log_message.length > 65535
     end
-    
+
     attribute_hash["resource_statuses_attributes"] = attribute_hash.delete("resource_statuses")
     attribute_hash["metrics_attributes"] = attribute_hash.delete("metrics")
     attribute_hash["resource_statuses_attributes"].each do |resource_status_hash|
@@ -198,7 +198,7 @@ class Report < ActiveRecord::Base
   def recalculate_report_status
     self.status = 'pending' if resource_statuses.any? {|rs| rs.status == 'pending' } &&
       resource_statuses.none? {|rs| rs.status == 'failed'}
-    self.status = 'failed' if self.logs.any? {|l| l.level == 'err' } 
+    self.status = 'failed' if self.logs.any? {|l| l.level == 'err' }
   end
 
   def add_missing_metrics

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -12,6 +12,7 @@ class Report < ActiveRecord::Base
 
   attr_accessible :host, :time, :status, :kind, :puppet_version, :configuration_version, :environment
   attr_accessible :logs_attributes, :metrics_attributes, :resource_statuses_attributes, :events_attributes
+  attr_accessible :transaction_uuid
 
   before_validation :assign_to_node
   validates_presence_of :host, :time, :kind

--- a/app/models/resource_status.rb
+++ b/app/models/resource_status.rb
@@ -5,10 +5,11 @@ class ResourceStatus < ActiveRecord::Base
   attr_readonly   :report_id
   attr_accessible :resource_type, :title, :evaluation_time, :file, :line, \
                   :tags, :time, :change_count, :out_of_sync_count, :skipped, \
-                  :failed, :status, :events_attributes, :report
+                  :failed, :status, :events_attributes, :report, :containment_path
   accepts_nested_attributes_for :events
 
   serialize :tags, Array
+  serialize :containment_path, Array
 
   scope :inspections, joins(:report).where("reports.kind = 'inspect'")
 

--- a/db/migrate/20150405234511_add_environment_to_reports.rb
+++ b/db/migrate/20150405234511_add_environment_to_reports.rb
@@ -1,0 +1,5 @@
+class AddEnvironmentToReports < ActiveRecord::Migration
+  def change
+    add_column :reports, :environment, :string
+  end
+end

--- a/db/migrate/20150406035502_add_transaction_uuid_to_reports.rb
+++ b/db/migrate/20150406035502_add_transaction_uuid_to_reports.rb
@@ -1,0 +1,5 @@
+class AddTransactionUuidToReports < ActiveRecord::Migration
+  def change
+    add_column :reports, :transaction_uuid, :string
+  end
+end

--- a/db/migrate/20150406035704_add_containment_path_to_resource_statuses.rb
+++ b/db/migrate/20150406035704_add_containment_path_to_resource_statuses.rb
@@ -1,0 +1,5 @@
+class AddContainmentPathToResourceStatuses < ActiveRecord::Migration
+  def change
+    add_column :resource_statuses, :containment_path, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141217071943) do
+ActiveRecord::Schema.define(:version => 20150405234511) do
 
   postgres = ActiveRecord::Base.connection.adapter_name.downcase =~ /postgres/
 
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(:version => 20141217071943) do
     t.string   "kind"
     t.string   "puppet_version"
     t.string   "configuration_version"
+    t.string   "environment"
   end
 
   add_index "reports", ["node_id"], :name => "index_reports_on_node_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150405234511) do
+ActiveRecord::Schema.define(:version => 20150406035704) do
 
   postgres = ActiveRecord::Base.connection.adapter_name.downcase =~ /postgres/
 
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(:version => 20150405234511) do
     t.string   "puppet_version"
     t.string   "configuration_version"
     t.string   "environment"
+    t.string   "transaction_uuid"
   end
 
   add_index "reports", ["node_id"], :name => "index_reports_on_node_id"
@@ -210,6 +211,7 @@ ActiveRecord::Schema.define(:version => 20150405234511) do
     t.boolean  "skipped"
     t.boolean  "failed"
     t.string   "status"
+    t.text     "containment_path"
   end
 
   add_index "resource_statuses", ["report_id"], :name => "index_resource_statuses_on_report_id"

--- a/lib/puppet/report_sanitizer.rb
+++ b/lib/puppet/report_sanitizer.rb
@@ -237,7 +237,7 @@ module ReportSanitizer #:nodoc:
   # format version 4 is used by puppet since version 3.3.0
   class FormatVersion4 < FormatVersion3
     def initialize(
-      log_sanitizer    = LogSanitizer.new,
+      log_sanitizer    = FormatVersion4LogSanitizer.new,
       metric_sanitizer = MetricSanitizer.new,
       status_sanitizer = FormatVersion4StatusSanitizer.new
     )
@@ -250,6 +250,16 @@ module ReportSanitizer #:nodoc:
       Util.copy_attributes(sanitized, raw, %w[kind status puppet_version configuration_version environment transaction_uuid])
     end
 
+    class FormatVersion4LogSanitizer < LogSanitizer
+      def sanitize(raw)
+        sanitized = super
+        unless sanitized['tags'].is_a?(Array)
+          sanitized['tags'] = raw['tags']['hash'].keys
+        end
+        sanitized
+      end
+    end
+
     class FormatVersion4StatusSanitizer < ExtendedStatusSanitizer
       def initialize(event_sanitizer = FormatVersion4EventSanitizer.new)
         super(event_sanitizer)
@@ -259,6 +269,11 @@ module ReportSanitizer #:nodoc:
         sanitized = super
         Util.verify_attributes(raw, %w[containment_path])
         Util.copy_attributes(sanitized, raw, %w[containment_path])
+
+        unless sanitized['tags'].is_a?(Array)
+          sanitized['tags'] = raw['tags']['hash'].keys
+        end
+        sanitized
       end
 
       class FormatVersion4EventSanitizer < ExtendedEventSanitizer

--- a/lib/puppet/report_sanitizer.rb
+++ b/lib/puppet/report_sanitizer.rb
@@ -7,7 +7,12 @@ module ReportSanitizer #:nodoc:
     def sanitize(raw)
       case
         when raw.include?('report_format')
-          format2sanitizer.sanitize(raw)
+          case raw['report_format']
+            when 2
+              format2sanitizer.sanitize(raw)
+            when 3
+              format3sanitizer.sanitize(raw)
+          end
         when raw.include?('resource_statuses')
           format1sanitizer.sanitize(raw)
         else
@@ -27,6 +32,10 @@ module ReportSanitizer #:nodoc:
 
     def format2sanitizer()
       @format2sanitizer ||= ReportSanitizer::FormatVersion2.new
+    end
+
+    def format3sanitizer()
+      @format3sanitizer ||= ReportSanitizer::FormatVersion3.new
     end
   end
 
@@ -207,6 +216,15 @@ module ReportSanitizer #:nodoc:
           Util.copy_attributes(sanitized, raw, %w[audited historical_value])
         end
       end
+    end
+  end
+
+  # format version 3 was used by puppet 2.7.13-3.2.4
+  class FormatVersion3 < FormatVersion2
+    def sanitize(raw)
+      sanitized = super
+      Util.verify_attributes(raw, %w[kind status puppet_version configuration_version environment])
+      Util.copy_attributes(sanitized, raw, %w[kind status puppet_version configuration_version environment])
     end
   end
 end

--- a/lib/puppet/report_sanitizer.rb
+++ b/lib/puppet/report_sanitizer.rb
@@ -135,7 +135,7 @@ module ReportSanitizer #:nodoc:
     end
   end
 
-  # format version 1 was used by puppet 2.6.x-2.7.12
+  # format version 1 was used by puppet 2.6.0-2.6.4
   class FormatVersion1 < Base
     def initialize(
       log_sanitizer    = VersionLogSanitizer.new,
@@ -169,7 +169,7 @@ module ReportSanitizer #:nodoc:
     end
   end
 
-  # format version 2 has been used since puppet 2.7.13
+  # format version 2 was used by puppet 2.6.5-2.7.11
   class FormatVersion2 < FormatVersion1
     def initialize(
       log_sanitizer    = LogSanitizer.new,

--- a/spec/lib/puppet/report_sanitizer_spec.rb
+++ b/spec/lib/puppet/report_sanitizer_spec.rb
@@ -633,5 +633,154 @@ HEREDOC
         hash["environment"].should == "production"
       end
     end
+
+    describe 'a format version 4 (puppet 3.3.0-) report' do
+      let :raw_report do
+        YAML.load(<<HEREDOC, :safe => :true, :deserialize_symbols => true)
+--- !ruby/object:Puppet::Transaction::Report
+  host: localhost
+  time: 2010-07-22 12:19:47.204207 -07:00
+  logs: []
+  metrics:
+    time: !ruby/object:Puppet::Util::Metric
+      name: time
+      label: Time
+      values:
+        - - config_retrieval
+          - Config retrieval
+          - 0.25
+        - - total
+          - Total
+          - 0.5
+    resources: !ruby/object:Puppet::Util::Metric
+      name: resources
+      label: Resources
+      values:
+        - - failed
+          - Failed
+          - 1
+        - - out_of_sync
+          - Out of sync
+          - 2
+        - - changed
+          - Changed
+          - 3
+        - - total
+          - Total
+          - 4
+    events: !ruby/object:Puppet::Util::Metric
+      name: events
+      label: Events
+      values:
+        - - total
+          - Total
+          - 0
+    changes: !ruby/object:Puppet::Util::Metric
+      name: changes
+      label: Changes
+      values:
+        - - total
+          - Total
+          - 0
+  resource_statuses:
+    File[/etc/motd]: !ruby/object:Puppet::Resource::Status
+      resource: File[/etc/motd]
+      file: /etc/puppetlabs/puppet/modules/motd/manifests/init.pp
+      line: 21
+      evaluation_time: 0.046776106
+      change_count: 1
+      out_of_sync_count: 1
+      tags:
+        - file
+        - class
+        - motd
+        - node
+        - default
+      time: 2013-10-02 16:54:44.845351 -07:00
+      events:
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          property: content
+          previous_value: \"{md5}576c30100670abe54a2446d05d72e4cf\"
+          desired_value: \"{md5}892b87473b3ce3afbcb28198ac02f02d\"
+          historical_value:
+          message: \"content changed '{md5}576c30100670abe54a2446d05d72e4cf' to '{md5}892b87473b3ce3afbcb28198ac02f02d'\"
+          name: !ruby/sym content_changed
+          status: success
+          time: 2013-10-02 16:54:44.885931 -07:00
+      out_of_sync: true
+      changed: true
+      resource_type: File
+      title: /etc/motd
+      skipped: false
+      failed: false
+      containment_path:
+        - Stage[main]
+        - Motd
+        - File[/etc/motd]
+    File[hello.rb]: !ruby/object:Puppet::Resource::Status
+      resource: File[hello.rb]
+      file: /etc/puppetlabs/puppet/modules/hello/manifests/init.pp
+      line: 47
+      evaluation_time: 0.108021493
+      change_count: 0
+      out_of_sync_count: 1
+      tags:
+        - file
+        - hello.rb
+        - class
+        - hello
+        - node
+        - default
+      time: 2013-10-02 16:54:49.012379 -07:00
+      events:
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          message: \"Could not find user abcdefghijklmnop\"
+          status: failure
+          time: 2013-10-02 16:54:49.120393 -07:00
+      out_of_sync: true
+      changed: false
+      resource_type: File
+      title: hello.rb
+      skipped: false
+      failed: true
+      containment_path:
+        - Stage[main]
+        - Hello
+        - File[hello.rb]
+  configuration_version: 12345
+  report_format: 4
+  puppet_version: 3.3.0
+  kind: apply
+  transaction_uuid: b2b7567c-696a-4250-8d74-e3c5030e1263
+  environment: production
+  status: unchanged
+HEREDOC
+      end
+
+      it "should produce a hash of the report" do
+        hash = ReportSanitizer.sanitize(raw_report)
+        hash.should be_a(Hash)
+        hash.keys.should =~ %w{host time logs metrics resource_statuses kind configuration_version puppet_version report_format status environment transaction_uuid}
+        hash["report_format"].should == 4
+        hash["host"].should == "localhost"
+        hash["time"].should == Time.parse("2010-07-22 12:19:47.204207 -07:00")
+        hash["environment"].should == "production"
+        hash["transaction_uuid"].should == "b2b7567c-696a-4250-8d74-e3c5030e1263"
+      end
+
+      it "should have resource_statuses that contain a containment_path" do
+        hash = ReportSanitizer.sanitize(raw_report)
+        hash.should be_a(Hash)
+        hash["resource_statuses"].values.each do |resource_status|
+          resource_status["containment_path"].should be_a(Array)
+        end
+      end
+
+      it "should allow resource events that do not contain property previous_value desired_value or historical_value" do
+        expect { ReportSanitizer.sanitize(raw_report) }.to_not raise_error ArgumentError
+      end
+    end
   end
 end

--- a/spec/lib/puppet/report_sanitizer_spec.rb
+++ b/spec/lib/puppet/report_sanitizer_spec.rb
@@ -494,5 +494,144 @@ HEREDOC
         hash["time"].should == Time.parse("2010-07-22 12:19:47.204207 -07:00")
       end
     end
+
+    describe 'a format version 3 (puppet 2.7.13-3.2.4) report' do
+      let :raw_report do
+        YAML.load(<<HEREDOC, :safe => :true, :deserialize_symbols => true)
+--- !ruby/object:Puppet::Transaction::Report
+  host: localhost
+  time: 2010-07-22 12:19:47.204207 -07:00
+  logs: []
+  metrics:
+    time: !ruby/object:Puppet::Util::Metric
+      name: time
+      label: Time
+      values:
+        - - config_retrieval
+          - Config retrieval
+          - 0.25
+        - - total
+          - Total
+          - 0.5
+    resources: !ruby/object:Puppet::Util::Metric
+      name: resources
+      label: Resources
+      values:
+        - - failed
+          - Failed
+          - 1
+        - - out_of_sync
+          - Out of sync
+          - 2
+        - - changed
+          - Changed
+          - 3
+        - - total
+          - Total
+          - 4
+    events: !ruby/object:Puppet::Util::Metric
+      name: events
+      label: Events
+      values:
+        - - total
+          - Total
+          - 0
+    changes: !ruby/object:Puppet::Util::Metric
+      name: changes
+      label: Changes
+      values:
+        - - total
+          - Total
+          - 0
+  resource_statuses:
+    File[/etc/motd]: !ruby/object:Puppet::Resource::Status
+      resource: File[/etc/motd]
+      file: /etc/puppetlabs/puppet/modules/motd/manifests/init.pp
+      line: 21
+      evaluation_time: 0.046776106
+      change_count: 1
+      out_of_sync_count: 1
+      tags:
+        - file
+        - class
+        - motd
+        - node
+        - default
+      time: 2013-10-02 16:54:44.845351 -07:00
+      events:
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          property: content
+          previous_value: \"{md5}576c30100670abe54a2446d05d72e4cf\"
+          desired_value: \"{md5}892b87473b3ce3afbcb28198ac02f02d\"
+          historical_value:
+          message: \"content changed '{md5}576c30100670abe54a2446d05d72e4cf' to '{md5}892b87473b3ce3afbcb28198ac02f02d'\"
+          name: !ruby/sym content_changed
+          status: success
+          time: 2013-10-02 16:54:44.885931 -07:00
+      out_of_sync: true
+      changed: true
+      resource_type: File
+      title: /etc/motd
+      skipped: false
+      failed: false
+      containment_path:
+        - Stage[main]
+        - Motd
+        - File[/etc/motd]
+    File[hello.rb]: !ruby/object:Puppet::Resource::Status
+      resource: File[hello.rb]
+      file: /etc/puppetlabs/puppet/modules/hello/manifests/init.pp
+      line: 47
+      evaluation_time: 0.108021493
+      change_count: 0
+      out_of_sync_count: 1
+      tags:
+        - file
+        - hello.rb
+        - class
+        - hello
+        - node
+        - default
+      time: 2013-10-02 16:54:49.012379 -07:00
+      events:
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          property:
+          previous_value:
+          desired_value:
+          historical_value:
+          message: \"Could not find user abcdefghijklmnop\"
+          status: failure
+          time: 2013-10-02 16:54:49.120393 -07:00
+      out_of_sync: true
+      changed: false
+      resource_type: File
+      title: hello.rb
+      skipped: false
+      failed: true
+      containment_path:
+        - Stage[main]
+        - Hello
+        - File[hello.rb]
+  configuration_version: 12345
+  report_format: 3
+  puppet_version: 2.7.20
+  kind: apply
+  environment: production
+  status: unchanged
+HEREDOC
+      end
+
+      it "should produce a hash of the report" do
+        hash = ReportSanitizer.sanitize(raw_report)
+        hash.should be_a(Hash)
+        hash.keys.should =~ %w{host time logs metrics resource_statuses kind configuration_version puppet_version report_format status environment}
+        hash["report_format"].should == 3
+        hash["host"].should == "localhost"
+        hash["time"].should == Time.parse("2010-07-22 12:19:47.204207 -07:00")
+        hash["environment"].should == "production"
+      end
+    end
   end
 end

--- a/spec/lib/puppet/report_sanitizer_spec.rb
+++ b/spec/lib/puppet/report_sanitizer_spec.rb
@@ -92,7 +92,7 @@ describe ReportSanitizer do
       end
     end
 
-    describe 'a format version 1 (puppet 2.6.x-2.7.12) report' do
+    describe 'a format version 1 (puppet 2.6.0-2.6.4) report' do
       let :report_filename do
         Rails.root.join('spec', 'fixtures', 'reports', 'puppet26', 'report_ok_service_started_ok.yaml')
       end
@@ -358,7 +358,7 @@ describe ReportSanitizer do
       end
     end
 
-    describe 'a format version 2 (puppet 2.7.13+) report' do
+    describe 'a format version 2 (puppet 2.6.5-2.7.11) report' do
       let :raw_report do
         YAML.load(<<HEREDOC, :safe => :true, :deserialize_symbols => true)
 --- !ruby/object:Puppet::Transaction::Report


### PR DESCRIPTION
As promised in #315, this PR adds support for report formats 3 and 4.  A few new columns needed to be created for new fields in the report.  Right now they are not displayed in the UI but they do get properly added to the DB.
