### PR TITLE
Rescue correct psych exception in  ResourceEvent::ValueWrapper

### DIFF
--- a/app/models/resource_event.rb
+++ b/app/models/resource_event.rb
@@ -4,7 +4,11 @@ class ResourceEvent < ActiveRecord::Base
   # Only perform YAMLization on non-strings.
   class ValueWrapper
     def self.load(val)
-      YAML.load(val) rescue val
+      begin
+        YAML.load(val)
+      rescue Exception
+        val
+      end
     end
 
     def self.dump(val)

--- a/spec/models/resource_event_spec.rb
+++ b/spec/models/resource_event_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper'
 
 describe ResourceEvent do
+  describe ResourceEvent::ValueWrapper do
+    describe "#load" do
+      it "should return a hash when given a yaml hash" do
+        test_hash = ResourceEvent::ValueWrapper.load "---\n:test: string\n"
+        test_hash.should be_a Hash
+      end
+
+      it "should return a string when given a string" do
+        test_string = ResourceEvent::ValueWrapper.load "test"
+        test_string.should be_a String
+      end
+
+      it "should return a string when given a string that is only special characters" do
+        test_string = ResourceEvent::ValueWrapper.load "*"
+        test_string.should be_a String
+      end
+    end
+  end
+
   describe "#<=>" do
     [%w{alpha ensure}, %w{zeta ensure}, %w{elfin ensure}].each do |input|
       it "should sort ensure before anything else" do


### PR DESCRIPTION
In ruby 1.9, psych raises a `SyntaxError` when it tries to load a string that is just special characters.  On its own `rescue` only rescues from a `StandardError` which is a sibling of `SyntaxError` in ruby 1.9 so the
error is not rescued.  Rescuing `Exception` will work in all versions of ruby.