### PR TITLE
Add node:hide rake task

### DIFF
--- a/lib/tasks/node.rake
+++ b/lib/tasks/node.rake
@@ -107,6 +107,18 @@ namespace :node do
       exit 1
     end
   end
+  
+  desc 'Hide a node'
+  task :hide => :environment do
+    begin
+      node = get_node(ENV['name'])
+      node.hidden = true
+      node.save!
+    rescue => e
+      puts e.message
+      exit 1
+    end
+  end
 
   desc 'Replace class(es) for a node'
   task :classes => :environment do


### PR DESCRIPTION
node:destory takes forever and often leads to memory issues.  So I added a hide function to mark hosts as hidden that I've decommissioned so that they stop reporting as unresponsive.  Usage:
cd /usr/share/puppet-dashboard/
rake RAILS_ENV=production node:hide name=NODENAME
