### PR TITLE
Change from MD5 to SHA256 digests

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -44,7 +44,7 @@ namespace :cert do
     cert_req.version = 0
     cert_req.subject = OpenSSL::X509::Name.new([["CN", SETTINGS.cn_name]])
     cert_req.public_key = key.public_key
-    cert_req.sign(key, OpenSSL::Digest::MD5.new)
+    cert_req.sign(key, OpenSSL::Digest::SHA256.new)
 
     begin
       PuppetHttps.put("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_request/#{CGI::escape(SETTINGS.cn_name)}",


### PR DESCRIPTION
Newer versions of Puppet does not support MD5:
> `#` puppet cert sign dashboard
> Error: unknown message digest algorithm