### PR TITLE
support Puppet Certificate API v1 with fallback to pre-v1 behavior

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -27,7 +27,12 @@ class PuppetHttps
 
   def self.put(url, content_type, data, authenticate = true)
     url = URI.parse(url)
-    req = Net::HTTP::Put.new(url.path)
+    if url.query.nil?
+      uristring = url.path
+    else
+      uristring = "#{url.path}?#{url.query}"
+    end
+    req = Net::HTTP::Put.new(uristring)
     req.content_type = content_type
     req.body = data
     res = make_ssl_request(url, req, authenticate)

--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -33,25 +33,80 @@ namespace :cert do
     end
   end
 
+  # Test server for Cert API v1 compatibility
+  def get_cert_api( settings )
+    cert_api = {
+      :server => "https://#{settings.ca_server}:#{settings.ca_port}",
+      :prefix => '/puppet-ca/v1',
+      :options => 'environment=production&',
+    }
+
+    print "Testing CA server for Certificate API v1 compatibility..." if verbose == true
+    begin
+      result = PuppetHttps.get("#{cert_api[:server]}#{cert_api[:prefix]}/certificate/ca?#{cert_api[:options]}", 's', false)
+    rescue Net::HTTPServerException => e
+      # 404s might indicate a pre-v1 API
+      if e.response.code != '404'
+        raise "Unable to request CA certificate from CA server #{settings.ca_server}: #{e.message}"
+      end
+    rescue SocketError => e
+      raise SocketError, "Unable to contact CA server #{settings.ca_server}: #{e.message}"
+    end
+
+    # Try pre-v1 API
+    if result.nil?
+      print "failed.\nTesting CA server for pre-v1 API compatibility..." if verbose == true
+      begin
+        v3result = PuppetHttps.get("#{cert_api[:server]}/production/certificate/ca", 's', false)
+      rescue Net::HTTPServerException => e
+        raise "Unable to request CA certificate from CA server #{settings.ca_server}: #{e.message}"
+      rescue SocketError => e
+        raise SocketError, "Unable to contact CA server #{settings.ca_server}: #{e.message}"
+      end
+
+      if !v3result.nil?
+        print "succeeded.\nPuppet master pre-v4 detected.\n" if verbose == true
+        # reset to original pre-v1 paths
+        cert_api[:prefix] = '/production'
+        cert_api[:options] = ''
+      else
+        cert_api[:ca_certificate] = v3result
+      end
+    else
+      print "succeeded.\nPuppet Certificate API v1 verified.\n" if verbose == true
+      cert_api[:ca_certificate] = result
+    end
+
+    return cert_api
+  end
+
   desc "Submit a certificate request to the Puppet Master"
   task :request => :environment do
     require 'openssl'
     require 'puppet_https'
     require 'cgi'
+    cert_api = get_cert_api( SETTINGS )
     key = OpenSSL::PKey::RSA.new(File.read(SETTINGS.private_key_path))
 
+    certname = CGI::escape(SETTINGS.cn_name)
     cert_req = OpenSSL::X509::Request.new
     cert_req.version = 0
     cert_req.subject = OpenSSL::X509::Name.new([["CN", SETTINGS.cn_name]])
     cert_req.public_key = key.public_key
     cert_req.sign(key, OpenSSL::Digest::SHA256.new)
 
+    print "Submitting certificate request to CA server..." if verbose == true
     begin
-      PuppetHttps.put("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_request/#{CGI::escape(SETTINGS.cn_name)}",
+      PuppetHttps.put("#{cert_api[:server]}#{cert_api[:prefix]}/certificate_request/#{certname}?#{cert_api[:options]}",
                       'text/plain', cert_req.to_s, false)
+
+    rescue Net::HTTPServerException => e
+      raise "Unable to submit certificate request to the CA server #{SETTINGS.ca_server}: #{e.message}"
+
     rescue SocketError => e
       raise SocketError, "Unable to contact CA server #{SETTINGS.ca_server}: #{e.message}"
     end
+    print "sent.\n"
   end
 
   desc "Retrieve a certificate from the Puppet Master"
@@ -59,8 +114,15 @@ namespace :cert do
     require 'openssl'
     require 'puppet_https'
     require 'cgi'
+
+    # Test Puppet API v1 first by grabbing CA certificate
+    cert_api = get_cert_api( SETTINGS )
+    certname = CGI::escape(SETTINGS.cn_name)
+
     begin
-      cert_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate/#{CGI::escape(SETTINGS.cn_name)}", 's', false)
+      print "Requesting the signed certificate from the CA server..." if verbose == true
+      cert_s = PuppetHttps.get("#{cert_api[:server]}#{cert_api[:prefix]}/certificate/#{certname}?#{cert_api[:options]}", 's', false)
+      print "got it.\n" if verbose == true
       cert = OpenSSL::X509::Certificate.new(cert_s)
       key = OpenSSL::PKey::RSA.new(File.read(SETTINGS.public_key_path))
       raise "Certificate doesn't match key" unless cert.public_key.to_s == key.to_s
@@ -69,17 +131,29 @@ namespace :cert do
         file.print cert_s
       end
 
-      ca_cert_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate/ca", 's', false)
-      ca_cert = OpenSSL::X509::Certificate.new(ca_cert_s)
+      # Store the CA certificate
+      ca_cert = OpenSSL::X509::Certificate.new(cert_api[:ca_certificate])
       raise "Certificate isn't signed by CA" unless cert.verify(ca_cert.public_key)
       File.open(SETTINGS.ca_certificate_path, 'w') do |file|
-        file.print ca_cert_s
+        file.print cert_api[:ca_certificate]
       end
 
-      ca_crl_s = PuppetHttps.get("https://#{SETTINGS.ca_server}:#{SETTINGS.ca_port}/production/certificate_revocation_list/ca", 's')
+      # Store the CA's CRL 
+      print "Requesting the CA's revocation list..." if verbose == true
+      ca_crl_s = PuppetHttps.get("#{cert_api[:server]}#{cert_api[:prefix]}/certificate_revocation_list/ca?#{cert_api[:options]}", 's')
       File.open(SETTINGS.ca_crl_path, 'w') do |file|
         file.print ca_crl_s
       end
+      print "got it.\n" if verbose == true
+
+    rescue Net::HTTPServerException => e
+      # 404s might indicate certificate hasn't been signed yet
+      if e.response.code == '404'
+        print "Certificate not found. Certificate may not yet be signed on #{SETTINGS.ca_server}.\n"
+      else
+        raise "Unable to retrieve certificate from CA server #{SETTINGS.ca_server}: #{e.message}"
+      end
+
     rescue SocketError => e
       raise SocketError, "Unable to contact CA server #{SETTINGS.ca_server}: #{e.message}"
     end


### PR DESCRIPTION
This attempts the v1 API first, then falls back if that fails but old URL paths work. It also adds some useful output and reports errors not previously available.

```
$ bundle exec rake -v cert:create_key_pair
$ bundle exec rake -v cert:request
Testing CA server for Certificate API v1 compatibility...succeeded.
Puppet Certificate API v1 verified.
Submitting certificate request to CA server...sent.

$ bundle exec rake cert:retrieve
Certificate not found. Certificate may not yet be signed on puppet.svcolo.com.
```

After signing the certificate on the server:

```
$ bundle exec rake -v cert:retrieve
Testing CA server for Certificate API v1 compatibility...succeeded.
Puppet Certificate API v1 verified.
Requesting the signed certificate from the CA server...got it.
Requesting the CA's revocation list...got it.
```

This completely resolves #331 
