### PR TITLE
Make debian init script respect DASHBOARD_ENVIRONMENT

### DIFF
--- a/ext/debian/puppet-dashboard-workers.init
+++ b/ext/debian/puppet-dashboard-workers.init
@@ -65,7 +65,7 @@ start_puppet_dashboard_workers() {
     start-stop-daemon  --start --quiet --oknodo --user ${DASHBOARD_USER} --chuid ${DASHBOARD_USER}  --exec /bin/bash -- -e -c "
                 export PATH='${PATH}';
                 export RUBYLIB='${RUBYLIB:-}';
-                export RAILS_ENV=production;
+                export RAILS_ENV=${DASHBOARD_ENVIRONMENT};
                 ${DASHBOARD_HOME}/script/delayed_job -p dashboard -n ${NUM_DELAYED_JOB_WORKERS:-2} -m start;"
     check_puppet_dashboard_worker_status
 }


### PR DESCRIPTION
Was previously hardcoded to 'production', I tried to run my workers in a develpoment environment (without a working production environment yet), and they broke.

This should retain the behavior of having it default to production environment, while using the proper environment when specified.
