### PR TITLE
dont remove the database.yml.example and settings.yml.example files

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -30,8 +30,6 @@ binary-install/puppet-dashboard::
 	chmod -R a+rx $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/script
 	rm -rf $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/ext/{redhat,debian,build_defaults.yaml,project_data.yaml}
 	# Clean up the "extra" files
-	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/config/database.yml.example
-	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/config/settings.yml.example
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/vendor/plugins/*/*LICENSE
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/vendor/plugins/*/License.txt
 	rm -f $(CURDIR)/debian/$(cdbs_curpkg)/usr/share/puppet-dashboard/vendor/gems/*/*LICENSE


### PR DESCRIPTION
Leave the database.yml.example and settings.yml.example files under /usr/share/puppet-dashboard/config when installed via deb package
