### PR TITLE
remove sqlite from travis db config

### DIFF
--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,11 +1,5 @@
 # Each of the sections matches a DB env in .travis.yml
 
-sqlite: &sqlite
-  adapter: sqlite3
-  database: db/dashboard_test.sqlite3
-  timeout: 5000
-  pool: 5
-
 mysql: &mysql
   adapter: mysql2
   username: root


### PR DESCRIPTION
sqlite has already been removed from `.travis` so remove from `config/database.yml.travis` as well