### PR TITLE
Add rubocop and haml-lint to default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,3 +65,11 @@ begin
 rescue LoadError
   STDERR.puts "Warning: Rails rake tasks currently unavailable because we can't find the 'rails' gem"
 end
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+require 'haml_lint/rake_task'
+HamlLint::RakeTask.new
+
+task :default => [:spec, :rubocop, :haml_lint]


### PR DESCRIPTION
This ensures the default task runs the same tests and lints we run with travis and hopefully helps to prevent bad surprises when opening a PR. closes #361 