### PR TITLE
Make rubocop and haml_lint tasks optional

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,10 +66,16 @@ rescue LoadError
   STDERR.puts "Warning: Rails rake tasks currently unavailable because we can't find the 'rails' gem"
 end
 
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new
+begin
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+rescue LoadError
+end
 
-require 'haml_lint/rake_task'
-HamlLint::RakeTask.new
+begin
+  require 'haml_lint/rake_task'
+  HamlLint::RakeTask.new
+rescue LoadError
+end
 
 task :default => [:spec, :rubocop, :haml_lint]


### PR DESCRIPTION
This gems are not usually installed in production and
this will lead to an error when running rake.