### PR TITLE
Remove puppetlabs references

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -270,6 +270,10 @@ function display_file_popup(url) {
     jQuery.colorbox({href: url, width: '80%', height: '80%', iframe: true});
 }
 
+function help_overlay(content) {
+    jQuery.colorbox({href: content, width: '60%', height: '80%'})
+}
+
 function init_sidebar_links() {
   jQuery( '.node_summary .primary tr' ).each( function() {
     jQuery( this )

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -41,11 +41,11 @@ class FilesController < ApplicationController
     if e.response.code == "403"
       text = "<p>Connection not authorized: #{e}</p>
         <p>You may not have generated your certificates.
-        <a target=\"_blank\" href=\"http://links.puppetlabs.com/dashboard_generating_certs\">View documentation</a></p>"
+        <a target=\"_blank\" href=\"https://github.com/sodabrew/puppet-dashboard/blob/master/docs/manual/configuring.markdown#generating-certs-and-connecting-to-the-puppet-master\">View documentation</a></p>"
     else
       text = "<p>File contents not available: #{e}</p>
         <p>Your agents may not be submitting files to a central filebucket.
-        <a target=\"_blank\" href=\"http://links.puppetlabs.com/enabling_the_filebucket_viewer\">View documentation</a></p>"
+        <a target=\"_blank\" href=\"https://github.com/sodabrew/puppet-dashboard/blob/master/docs/manual/configuring.markdown#enabling-the-filebucket-viewer\">View documentation</a></p>"
     end
     render html: ActionController::Base.helpers.sanitize(text), status: e.response.code
   rescue Errno::ECONNREFUSED => e

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,0 +1,7 @@
+class HelpController < ApplicationController
+  def node_status
+    respond_to do |format|
+      format.html { render(partial: 'node_status') }
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -270,4 +270,9 @@ module ApplicationHelper
   def add_body_class(klass)
     (@body_classes ||= []).push(klass).uniq!
   end
+
+  def help_overlay(action)
+    url = url_for controller: :help, action: action
+    link_to 'Help', '#', onclick: "help_overlay('#{url}'); return false;", class: 'popup-md5'
+  end
 end

--- a/app/views/help/_node_status.html.haml
+++ b/app/views/help/_node_status.html.haml
@@ -1,0 +1,19 @@
+%h2= 'In Puppet Dashboard, every node is in one of six states:'
+
+%span{style: 'font-family: Helvetica, Arial, Verdana; font-size: larger; color: #888;'}= 'Unresponsive:'
+%p= "This node hasn't reported to the puppet master recently; something may be wrong. The cutoff for considering a node unresponsive defaults to one hour, and can be configured in `settings.yml` with the `no_longer_reporting_cutoff` setting."
+
+%span{style: 'font-family: Helvetica, Arial, Verdana; font-size: larger; color: #c21;'}= 'Failed:'
+%p= "During its last Puppet run, this node encountered some error from which it couldn't recover. Something is probably wrong, and investigation is recommended."
+
+%span{style: 'font-family: Helvetica, Arial, Verdana; font-size: larger; color: #e72;'}= 'Pending:'
+%p= "During its last Puppet run, this node _would_ have made changes, but it was either running in no-op mode or found a discrepancy in a resource whose `noop` metaparameter was set to `true`."
+
+%span{style: 'font-family: Helvetica, Arial, Verdana; font-size: larger; color: #069;'}= 'Changed:'
+%p= "This node's last Puppet run was successful, and changes were made to bring the node into compliance."
+
+%span{style: 'font-family: Helvetica, Arial, Verdana; font-size: larger; color: #093;'}= 'Unchanged:'
+%p= "This node's last Puppet run was successful, and it was fully compliant; no changes were necessary."
+
+%span{style: 'font-family: Helvetica, Arial, Verdana; font-size: larger; color: #aaa;'}= 'Unreported:'
+%p= "Although Dashboard is aware of this node's existence, it has never submitted a Puppet report. It may be a newly-commissioned node, it may have never come online, or its copy of Puppet may not be configured correctly."

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -38,6 +38,6 @@
         = yield
       #footer
         %p
-          = link_to raw("&copy; Copyright #{Time.now.year} Puppet Labs"), 'http://puppetlabs.com/'
+          = link_to raw("Puppet Dashboard"), 'https://github.com/sodabrew/puppet-dashboard'
           &mdash;
           = link_to h(APP_VERSION), APP_VERSION_LINK

--- a/app/views/shared/_node_manager_sidebar.html.haml
+++ b/app/views/shared/_node_manager_sidebar.html.haml
@@ -17,8 +17,7 @@
 .group
   %h3{:class => active_if(controller_name == "nodes" && action_name == "index")}= link_to "Nodes", nodes_path
   %p.help
-    %a{ :href => 'http://links.puppetlabs.com/dashboard1.2_node_summary_help', :target => '_blank' }
-      Help
+    = help_overlay('node_status')
   .node_summary
     %table.primary
       - node_summary = Node.count_by_status

--- a/config/initializers/app_version_init.rb
+++ b/config/initializers/app_version_init.rb
@@ -20,7 +20,7 @@ def get_app_version_link
   if File.exists?(Rails.root.join('VERSION_LINK'))
     return File.read(Rails.root.join('VERSION_LINK')).strip
   else
-    return "https://github.com/puppetlabs/puppet-dashboard/commits/#{APP_VERSION.sub(/.*?g([0-9a-f]*)/, "\\1")}"
+    return "https://github.com/sodabrew/puppet-dashboard/commits/#{APP_VERSION.sub(/.*?g([0-9a-f]*)/, "\\1")}"
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,4 +77,6 @@ Rails.application.routes.draw do
   get 'release_notes', to: 'pages#release_notes'
 
   get 'radiator(.:format)', to: 'radiator#index'
+
+  get 'help/node_status', to: 'help#node_status'
 end

--- a/docs/manual/bootstrapping.markdown
+++ b/docs/manual/bootstrapping.markdown
@@ -113,7 +113,7 @@ On Debian-based systems, install Puppet Dashboard via Apt:
 
 If you're unable to use the Dashboard packages on your system, the next best way to install Dashboard is from the Puppet Labs Git repo. In the directory where you want Dashboard installed (we suggest `/opt/` or `/usr/share/`), run: 
 
-    git clone git://github.com/puppetlabs/puppet-dashboard.git
+    git clone git://github.com/sodabrew/puppet-dashboard.git
     cd puppet-dashboard
     git checkout v1.2.0
 


### PR DESCRIPTION
This removes (hopefully) all the puppetlabs references in the application itself. There may still be some in the old manual, but that needs an overhaul anyway.

There was also a link to a little summary about what the node states mean (little help button on the node summary block) which was pointing to a no longer existing page. I replaced it with a in-app help overlay with the jquery-colorbox which is also used in the file diff view.