### PR TITLE
Replace deprecated link_to_function with link_to

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,7 +31,7 @@
           - if message = flash[type]
             - type = :warning if type == :alert
             %div.section#flash{:class => type}
-              .close= link_to_function icon(:close), "jQuery('#flash').hide()"
+              .close= link_to icon(:close), '#', onclick: "jQuery('#flash').hide(); return false;"
               %p
                 = icon(type)
                 = h message


### PR DESCRIPTION
link_to_function is no longer present in Rails, replaced it with a
link_to call with an onclick attrib instead