### PR TITLE
permits :description param in new_node_groups

### DIFF
--- a/app/controllers/node_groups_controller.rb
+++ b/app/controllers/node_groups_controller.rb
@@ -100,6 +100,7 @@ class NodeGroupsController < InheritedResources::Base
   def node_group_params
     params.require(:node_group).permit(
       :name,
+      :description,
       :assigned_node_ids => [],
       :assigned_node_class_ids => [],
       :assigned_node_group_ids => [],

--- a/spec/controllers/node_groups_controller_spec.rb
+++ b/spec/controllers/node_groups_controller_spec.rb
@@ -12,7 +12,7 @@ describe NodeGroupsController, :type => :controller do
 
   describe "#create" do
     it "should create a node group on successful creation" do
-      post :create, params: { node_group: { name: 'foo' } }
+      post :create, params: { node_group: { name: 'foo', description: 'foo' } }
       assigns[:node_group].name.should == 'foo'
     end
 


### PR DESCRIPTION
To add a :description to a NodeGroup upon creation, new_node_group must permit the :description command.
```
Started POST "/node_groups" for 127.0.0.1 at 2020-06-26 14:38:34 -0700
Processing by NodeGroupsController#create as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"cpgS7UPu3vVlZR9+2F9R6tKjJdslJGp3xolRnmNPDsZ+smcpy8ANhTmB1oJnPutHjMUQI8AHztgiErNRx7nBTw==", "force_create"=>"false", "node_group"=>{"name"=>"test_description", "description"=>"This doesn't get saved when creating a new group.", "parameter_attributes"=>[{"key"=>"", "value"=>""}], "assigned_node_class_ids"=>[""], "assigned_node_group_ids"=>[""], "assigned_node_ids"=>[""]}}
   (0.1ms)  BEGIN
  ↳ app/controllers/node_groups_controller.rb:19
Unpermitted parameter: :description
Unpermitted parameter: :description
Unpermitted parameter: :description
```