### PR TITLE
Moves validation to belongs_to associations for NodeGroup (and class) memberships

### DIFF
--- a/app/models/node_group_class_membership.rb
+++ b/app/models/node_group_class_membership.rb
@@ -1,10 +1,8 @@
 class NodeGroupClassMembership < ApplicationRecord
-  validates_presence_of :node_class_id, :node_group_id
-
   include NodeGroupGraph
 
   has_parameters
 
-  belongs_to :node_class
-  belongs_to :node_group
+  belongs_to :node_class, required: true
+  belongs_to :node_group, required: true
 end

--- a/app/models/node_group_membership.rb
+++ b/app/models/node_group_membership.rb
@@ -1,9 +1,8 @@
 class NodeGroupMembership < ApplicationRecord
-  validates_presence_of :node_id, :node_group_id
   validates_uniqueness_of :node_id, :scope => :node_group_id
 
-  belongs_to :node
-  belongs_to :node_group
+  belongs_to :node, required: true
+  belongs_to :node_group, required: true
 
   def to_json(*args)
     {"node_group_id" => node_group_id, "node_id" => node_id}.to_json(*args)


### PR DESCRIPTION
…alidations to belongs_to association

Right now we can't create new NodeGroups that have existing Nodes and/or NodeClasses assigned. NodeGroupMemberships couldn't validate the presence of a NodeGroup since there was no node_group_id yet. Moving the validations to the belongs_to association seems to fix the ordering.

NodeGroupClassMemberships creation fails in a similar manner.