### PR TITLE
Unescape HTML in inventory partial so inventory renders

### DIFF
--- a/app/views/nodes/_inventory_service.html.haml
+++ b/app/views/nodes/_inventory_service.html.haml
@@ -4,6 +4,6 @@
     %div#inventory
       = image_tag "/images/loading.gif"
       = "Loading node inventory"
-    %script{:type => 'text/javascript'}= load_asynchronously("div#inventory", facts_node_path(node))
+    %script{:type => 'text/javascript'}!= load_asynchronously("div#inventory", facts_node_path(node))
 
   %br.clear


### PR DESCRIPTION
The inventory partial wasn't rendering because the single quotes were getting encoded improperly:

`<script type='text/javascript'>jQuery.get(&#39;/nodes/dbrestore14-a.sf2p.intern.weebly.net/facts&#39;, function(data) { jQuery(&#39;div#inventory&#39;).html(data) })</script>`

Adding the exclamation (!) to unescape the HTML allows the inventory to render properly.