### PR TITLE
Migrate to `ruby/setup-ruby` in `code-style-review.yaml`

### DIFF
--- a/.github/workflows/code-style-review.yaml
+++ b/.github/workflows/code-style-review.yaml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: 'Set up Ruby'
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1.111.0
       with:
         ruby-version: '2.6'
 

--- a/.github/workflows/code-style-review.yaml
+++ b/.github/workflows/code-style-review.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: 'Set up Ruby'
       uses: ruby/setup-ruby@v1.111.0
       with:
-        ruby-version: '2.6'
+        ruby-version: '2.7'
 
     - name: 'Set up Reviewdog'
       env:


### PR DESCRIPTION
Move to `ruby/setup-ruby` latest since `actions/setup-ruby` was deprecated.
Use current latest version `v1.111.0`
Also bump ruby version 2.7 so reviewdog works